### PR TITLE
feat: 소셜 로그인 창으로 redirect 기능 추가

### DIFF
--- a/src/main/kotlin/com/celuveat/common/exception/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/celuveat/common/exception/ExceptionControllerAdvice.kt
@@ -2,10 +2,12 @@ package com.celuveat.common.exception
 
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class ExceptionControllerAdvice {
@@ -41,6 +43,23 @@ class ExceptionControllerAdvice {
         )
         return ResponseEntity.badRequest().body(
             ExceptionResponse("잘못된 요청입니다.")
+        )
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFoundException(
+        request: HttpServletRequest,
+        e: NoResourceFoundException
+    ): ResponseEntity<ExceptionResponse> {
+        log.warn(
+            """
+            존재하지 않는 리소스에 요청이 들어왔습니다.
+            URI: ${request.requestURI}
+            내용: ${e.message}
+            """
+        )
+        return ResponseEntity.status(NOT_FOUND).body(
+            ExceptionResponse("요청한 리소스를 찾을 수 없습니다.")
         )
     }
 

--- a/src/main/kotlin/com/celuveat/common/utils/CollectionsExtenstions.kt
+++ b/src/main/kotlin/com/celuveat/common/utils/CollectionsExtenstions.kt
@@ -1,0 +1,5 @@
+package com.celuveat.common.utils
+
+inline fun <reified T> Set<T>.doesNotContain(element: T): Boolean {
+    return !contains(element)
+}

--- a/src/main/kotlin/com/celuveat/common/utils/ValidationUtils.kt
+++ b/src/main/kotlin/com/celuveat/common/utils/ValidationUtils.kt
@@ -1,0 +1,5 @@
+package com.celuveat.common.utils
+
+inline fun throwWhen(condition: Boolean, exceptionSupplier: () -> RuntimeException) {
+    if (condition) throw exceptionSupplier()
+}

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -26,8 +26,9 @@ class SocialLoginController(
     fun login(
         @PathVariable socialLoginType: SocialLoginType,
         @RequestParam authCode: String,
+        @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
     ): LoginResponse {
-        val memberId = socialLoginUseCase.login(socialLoginType, authCode)
+        val memberId = socialLoginUseCase.login(socialLoginType, authCode, requestOrigin)
         val token = createAccessTokenUseCase.create(memberId)
         return LoginResponse.from(token)
     }
@@ -38,7 +39,7 @@ class SocialLoginController(
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
         response: HttpServletResponse,
     ) {
-        val socialLoginUrl = getSocialLoginUrlUseCase.getSocialLoginUrl(requestOrigin, socialLoginType)
+        val socialLoginUrl = getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin)
         response.sendRedirect(socialLoginUrl)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -2,10 +2,14 @@ package com.celuveat.member.adapter.`in`.rest
 
 import com.celuveat.auth.application.port.`in`.CreateAccessTokenUseCase
 import com.celuveat.member.adapter.`in`.rest.response.LoginResponse
+import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
 import com.celuveat.member.domain.SocialLoginType
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 class SocialLoginController(
     private val socialLoginUseCase: SocialLoginUseCase,
     private val createAccessTokenUseCase: CreateAccessTokenUseCase,
+    private val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
 ) {
 
     @GetMapping("/login/{socialLoginType}")
@@ -25,5 +30,15 @@ class SocialLoginController(
         val memberId = socialLoginUseCase.login(socialLoginType, authCode)
         val token = createAccessTokenUseCase.create(memberId)
         return LoginResponse.from(token)
+    }
+
+    @GetMapping("/login/{socialLoginType}/url")
+    fun redirectLoginUrl(
+        @PathVariable socialLoginType: SocialLoginType,
+        @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
+        response: HttpServletResponse,
+    ) {
+        val socialLoginUrl = getSocialLoginUrlUseCase.getSocialLoginUrl(requestOrigin, socialLoginType)
+        response.sendRedirect(socialLoginUrl)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -4,6 +4,7 @@ import com.celuveat.auth.application.port.`in`.CreateAccessTokenUseCase
 import com.celuveat.member.adapter.`in`.rest.response.LoginResponse
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
+import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 import com.celuveat.member.domain.SocialLoginType
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
@@ -28,7 +29,8 @@ class SocialLoginController(
         @RequestParam authCode: String,
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
     ): LoginResponse {
-        val memberId = socialLoginUseCase.login(socialLoginType, authCode, requestOrigin)
+        val command = SocialLoginCommand(socialLoginType, authCode, requestOrigin)
+        val memberId = socialLoginUseCase.login(command)
         val token = createAccessTokenUseCase.create(memberId)
         return LoginResponse.from(token)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -2,6 +2,7 @@ package com.celuveat.member.adapter.out.oauth
 
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
+import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
 import com.celuveat.member.exception.NotSupportedSocialLoginTypeException
@@ -9,7 +10,7 @@ import com.celuveat.member.exception.NotSupportedSocialLoginTypeException
 @Adapter
 class FetchSocialMemberAdapter(
     private val socialLoginClients: Set<SocialLoginClient>,
-) : FetchSocialMemberPort {
+) : FetchSocialMemberPort, GetSocialLoginUrlPort {
 
     override fun fetchMember(socialLoginType: SocialLoginType, authCode: String): Member {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
@@ -19,5 +20,10 @@ class FetchSocialMemberAdapter(
     private fun getSocialLoginClient(socialLoginType: SocialLoginType): SocialLoginClient {
         return socialLoginClients.firstOrNull { it.isSupports(socialLoginType) }
             ?: throw NotSupportedSocialLoginTypeException(socialLoginType)
+    }
+
+    override fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String {
+        val socialLoginClient = getSocialLoginClient(socialLoginType)
+        return socialLoginClient.getSocialLoginUrl(redirectUrl)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -12,9 +12,9 @@ class FetchSocialMemberAdapter(
     private val socialLoginClients: Set<SocialLoginClient>,
 ) : FetchSocialMemberPort, GetSocialLoginUrlPort {
 
-    override fun fetchMember(socialLoginType: SocialLoginType, authCode: String): Member {
+    override fun fetchMember(socialLoginType: SocialLoginType, authCode: String, redirectUrl: String): Member {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
-        return socialLoginClient.fetchMember(authCode)
+        return socialLoginClient.fetchMember(authCode, redirectUrl)
     }
 
     private fun getSocialLoginClient(socialLoginType: SocialLoginType): SocialLoginClient {
@@ -22,7 +22,7 @@ class FetchSocialMemberAdapter(
             ?: throw NotSupportedSocialLoginTypeException(socialLoginType)
     }
 
-    override fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String {
+    override fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
         return socialLoginClient.getSocialLoginUrl(redirectUrl)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
@@ -6,4 +6,5 @@ import com.celuveat.member.domain.SocialLoginType
 interface SocialLoginClient {
     fun isSupports(socialLoginType: SocialLoginType): Boolean
     fun fetchMember(authCode: String): Member
+    fun getSocialLoginUrl(redirectUrl: String): String
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
@@ -5,6 +5,6 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface SocialLoginClient {
     fun isSupports(socialLoginType: SocialLoginType): Boolean
-    fun fetchMember(authCode: String): Member
+    fun fetchMember(authCode: String, redirectUrl: String): Member
     fun getSocialLoginUrl(redirectUrl: String): String
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -1,10 +1,12 @@
 package com.celuveat.member.adapter.out.oauth.google
 
+import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.oauth.SocialLoginClient
 import com.celuveat.member.adapter.out.oauth.google.response.GoogleMemberInfoResponse
 import com.celuveat.member.adapter.out.oauth.google.response.GoogleSocialLoginToken
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
+import com.celuveat.member.exception.NotAllowedRedirectUriException
 import org.springframework.stereotype.Component
 import org.springframework.web.util.UriComponentsBuilder
 
@@ -19,8 +21,13 @@ class GoogleSocialLoginClient(
     }
 
     override fun fetchMember(authCode: String, redirectUrl: String): Member {
+        validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
+    }
+
+    private fun validateAllowedRedirectUrl(redirectUrl: String) {
+        throwWhen(googleSocialLoginProperty.allowedRedirectUris.none { it == redirectUrl }) { NotAllowedRedirectUriException }
     }
 
     private fun fetchAccessToken(authCode: String, redirectUrl: String): GoogleSocialLoginToken {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -18,18 +18,18 @@ class GoogleSocialLoginClient(
         return socialLoginType == SocialLoginType.GOOGLE
     }
 
-    override fun fetchMember(authCode: String): Member {
-        val socialLoginToken = fetchAccessToken(authCode)
+    override fun fetchMember(authCode: String, redirectUrl: String): Member {
+        val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
     }
 
-    private fun fetchAccessToken(authCode: String): GoogleSocialLoginToken {
+    private fun fetchAccessToken(authCode: String, redirectUrl: String): GoogleSocialLoginToken {
         val tokenRequestBody = mapOf(
             "grant_type" to "authorization_code",
             "client_id" to googleSocialLoginProperty.clientId,
             "client_secret" to googleSocialLoginProperty.clientSecret,
             "code" to authCode,
-            "redirect_uri" to googleSocialLoginProperty.redirectUri,
+            "redirect_uri" to redirectUrl,
         )
         return googleApiClient.fetchToken(tokenRequestBody)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -6,6 +6,7 @@ import com.celuveat.member.adapter.out.oauth.google.response.GoogleSocialLoginTo
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
 import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
 
 @Component
 class GoogleSocialLoginClient(
@@ -35,5 +36,16 @@ class GoogleSocialLoginClient(
 
     private fun fetchMemberInfo(accessToken: String): GoogleMemberInfoResponse {
         return googleApiClient.fetchMemberInfo("Bearer $accessToken")
+    }
+
+    override fun getSocialLoginUrl(redirectUrl: String): String {
+        return UriComponentsBuilder
+            .fromHttpUrl(googleSocialLoginProperty.authorizationUrl)
+            .queryParam("client_id", googleSocialLoginProperty.clientId)
+            .queryParam("redirect_uri", redirectUrl)
+            .queryParam("response_type", "code")
+            .queryParam("scope", googleSocialLoginProperty.scope.joinToString(","))
+            .build()
+            .toUriString()
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -1,5 +1,6 @@
 package com.celuveat.member.adapter.out.oauth.google
 
+import com.celuveat.common.utils.doesNotContain
 import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.oauth.SocialLoginClient
 import com.celuveat.member.adapter.out.oauth.google.response.GoogleMemberInfoResponse
@@ -27,7 +28,8 @@ class GoogleSocialLoginClient(
     }
 
     private fun validateAllowedRedirectUrl(redirectUrl: String) {
-        throwWhen(googleSocialLoginProperty.allowedRedirectUris.none { it == redirectUrl }) { NotAllowedRedirectUriException }
+        val allowedRedirectUris = googleSocialLoginProperty.allowedRedirectUris
+        throwWhen(allowedRedirectUris.doesNotContain(redirectUrl)) { NotAllowedRedirectUriException }
     }
 
     private fun fetchAccessToken(authCode: String, redirectUrl: String): GoogleSocialLoginToken {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginProperty.kt
@@ -7,5 +7,7 @@ data class GoogleSocialLoginProperty(
     val redirectUri: String,
     val clientId: String,
     val clientSecret: String,
-    val scope: List<String>
-)
+    val scope: List<String>,
+    val authorizationUrl: String = "https://accounts.google.com/o/oauth2/v2/auth",
+) {
+}

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginProperty.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "oauth.google")
 data class GoogleSocialLoginProperty(
-    val redirectUri: String,
+    val allowedRedirectUris: Set<String>,
     val clientId: String,
     val clientSecret: String,
     val scope: List<String>,

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -1,5 +1,6 @@
 package com.celuveat.member.adapter.out.oauth.kakao
 
+import com.celuveat.common.utils.doesNotContain
 import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.oauth.SocialLoginClient
 import com.celuveat.member.adapter.out.oauth.kakao.response.KakaoMemberInfoResponse
@@ -27,7 +28,8 @@ class KakaoSocialLoginClient(
     }
 
     private fun validateAllowedRedirectUrl(redirectUrl: String) {
-        throwWhen(kakaoSocialLoginProperty.allowedRedirectUris.none { it == redirectUrl }) { NotAllowedRedirectUriException }
+        val allowedRedirectUris = kakaoSocialLoginProperty.allowedRedirectUris
+        throwWhen(allowedRedirectUris.doesNotContain(redirectUrl)) { NotAllowedRedirectUriException }
     }
 
     private fun fetchAccessToken(authCode: String, redirectUrl: String): KakaoSocialLoginToken {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -6,6 +6,7 @@ import com.celuveat.member.adapter.out.oauth.kakao.response.KakaoSocialLoginToke
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
 import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
 
 @Component
 class KakaoSocialLoginClient(
@@ -35,5 +36,16 @@ class KakaoSocialLoginClient(
 
     private fun fetchMemberInfo(accessToken: String): KakaoMemberInfoResponse {
         return kakaoApiClient.fetchMemberInfo("Bearer $accessToken")
+    }
+
+    override fun getSocialLoginUrl(redirectUrl: String): String {
+        return UriComponentsBuilder
+            .fromHttpUrl(kakaoSocialLoginProperty.authorizationUrl)
+            .queryParam("client_id", kakaoSocialLoginProperty.clientId)
+            .queryParam("redirect_uri", redirectUrl)
+            .queryParam("response_type", "code")
+            .queryParam("scope", kakaoSocialLoginProperty.scope.joinToString(","))
+            .build()
+            .toUriString()
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -18,16 +18,16 @@ class KakaoSocialLoginClient(
         return socialLoginType == SocialLoginType.KAKAO
     }
 
-    override fun fetchMember(authCode: String): Member {
-        val socialLoginToken = fetchAccessToken(authCode)
+    override fun fetchMember(authCode: String, redirectUrl: String): Member {
+        val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
     }
 
-    private fun fetchAccessToken(authCode: String): KakaoSocialLoginToken {
+    private fun fetchAccessToken(authCode: String, redirectUrl: String): KakaoSocialLoginToken {
         val tokenRequestBody = mapOf(
             "grant_type" to "authorization_code",
             "client_id" to kakaoSocialLoginProperty.clientId,
-            "redirect_uri" to kakaoSocialLoginProperty.redirectUri,
+            "redirect_uri" to redirectUrl,
             "code" to authCode,
             "client_secret" to kakaoSocialLoginProperty.clientSecret
         )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -1,10 +1,12 @@
 package com.celuveat.member.adapter.out.oauth.kakao
 
+import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.oauth.SocialLoginClient
 import com.celuveat.member.adapter.out.oauth.kakao.response.KakaoMemberInfoResponse
 import com.celuveat.member.adapter.out.oauth.kakao.response.KakaoSocialLoginToken
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
+import com.celuveat.member.exception.NotAllowedRedirectUriException
 import org.springframework.stereotype.Component
 import org.springframework.web.util.UriComponentsBuilder
 
@@ -19,8 +21,13 @@ class KakaoSocialLoginClient(
     }
 
     override fun fetchMember(authCode: String, redirectUrl: String): Member {
+        validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
+    }
+
+    private fun validateAllowedRedirectUrl(redirectUrl: String) {
+        throwWhen(kakaoSocialLoginProperty.allowedRedirectUris.none { it == redirectUrl }) { NotAllowedRedirectUriException }
     }
 
     private fun fetchAccessToken(authCode: String, redirectUrl: String): KakaoSocialLoginToken {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginProperty.kt
@@ -9,4 +9,5 @@ data class KakaoSocialLoginProperty(
     val clientSecret: String,
     val scope: List<String>,
     val adminKey: String,
+    val authorizationUrl: String = "https://kauth.kakao.com/oauth/authorize",
 )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginProperty.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "oauth.kakao")
 data class KakaoSocialLoginProperty(
-    val redirectUri: String,
+    val allowedRedirectUris: Set<String>,
     val clientId: String,
     val clientSecret: String,
     val scope: List<String>,

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -18,7 +18,7 @@ class NaverSocialLoginClient(
         return socialLoginType == SocialLoginType.NAVER
     }
 
-    override fun fetchMember(authCode: String): Member {
+    override fun fetchMember(authCode: String, redirectUrl: String): Member {
         val socialLoginToken = fetchAccessToken(authCode)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -1,10 +1,12 @@
 package com.celuveat.member.adapter.out.oauth.naver
 
+import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.oauth.SocialLoginClient
 import com.celuveat.member.adapter.out.oauth.naver.response.NaverMemberInfoResponse
 import com.celuveat.member.adapter.out.oauth.naver.response.NaverSocialLoginToken
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
+import com.celuveat.member.exception.NotAllowedRedirectUriException
 import org.springframework.stereotype.Component
 import org.springframework.web.util.UriComponentsBuilder
 
@@ -19,8 +21,13 @@ class NaverSocialLoginClient(
     }
 
     override fun fetchMember(authCode: String, redirectUrl: String): Member {
+        validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
+    }
+
+    private fun validateAllowedRedirectUrl(redirectUrl: String) {
+        throwWhen(naverSocialLoginProperty.allowedRedirectUris.none { it == redirectUrl }) { NotAllowedRedirectUriException }
     }
 
     private fun fetchAccessToken(authCode: String): NaverSocialLoginToken {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -1,5 +1,6 @@
 package com.celuveat.member.adapter.out.oauth.naver
 
+import com.celuveat.common.utils.doesNotContain
 import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.oauth.SocialLoginClient
 import com.celuveat.member.adapter.out.oauth.naver.response.NaverMemberInfoResponse
@@ -27,7 +28,8 @@ class NaverSocialLoginClient(
     }
 
     private fun validateAllowedRedirectUrl(redirectUrl: String) {
-        throwWhen(naverSocialLoginProperty.allowedRedirectUris.none { it == redirectUrl }) { NotAllowedRedirectUriException }
+        val allowedRedirectUris = naverSocialLoginProperty.allowedRedirectUris
+        throwWhen(allowedRedirectUris.doesNotContain(redirectUrl)) { NotAllowedRedirectUriException }
     }
 
     private fun fetchAccessToken(authCode: String): NaverSocialLoginToken {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -6,6 +6,7 @@ import com.celuveat.member.adapter.out.oauth.naver.response.NaverSocialLoginToke
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
 import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
 
 @Component
 class NaverSocialLoginClient(
@@ -35,5 +36,16 @@ class NaverSocialLoginClient(
 
     private fun fetchMemberInfo(accessToken: String): NaverMemberInfoResponse {
         return naverApiClient.fetchMemberInfo("Bearer $accessToken")
+    }
+
+    override fun getSocialLoginUrl(redirectUrl: String): String {
+        return UriComponentsBuilder
+            .fromHttpUrl(naverSocialLoginProperty.authorizationUrl)
+            .queryParam("client_id", naverSocialLoginProperty.clientId)
+            .queryParam("redirect_uri", redirectUrl)
+            .queryParam("response_type", "code")
+            .queryParam("state", naverSocialLoginProperty.state)
+            .build()
+            .toUriString()
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginProperty.kt
@@ -9,4 +9,5 @@ data class NaverSocialLoginProperty(
     val clientSecret: String,
     val scope: List<String>,
     val state: String,
+    val authorizationUrl: String = "https://nid.naver.com/oauth2.0/authorize",
 )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginProperty.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "oauth.naver")
 data class NaverSocialLoginProperty(
-    val redirectUri: String,
+    val allowedRedirectUris: Set<String>,
     val clientId: String,
     val clientSecret: String,
     val scope: List<String>,

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -2,6 +2,7 @@ package com.celuveat.member.application
 
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
+import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
 import com.celuveat.member.application.port.out.FindMemberPort
 import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
@@ -19,8 +20,12 @@ class SocialLoginService(
 ) : SocialLoginUseCase, GetSocialLoginUrlUseCase {
 
     @Transactional
-    override fun login(socialLoginType: SocialLoginType, authCode: String, requestOrigin: String): Long {
-        val member = fetchSocialMemberPort.fetchMember(socialLoginType, authCode, requestOrigin)
+    override fun login(command: SocialLoginCommand): Long {
+        val member = fetchSocialMemberPort.fetchMember(
+            command.socialLoginType,
+            command.authCode,
+            command.requestOrigin,
+        )
         val signInMember = findMemberPort.findBySocialIdentifier(member.socialIdentifier)
             ?: saveMemberPort.save(member)
         return signInMember.id

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -19,14 +19,14 @@ class SocialLoginService(
 ) : SocialLoginUseCase, GetSocialLoginUrlUseCase {
 
     @Transactional
-    override fun login(socialLoginType: SocialLoginType, authCode: String): Long {
-        val member = fetchSocialMemberPort.fetchMember(socialLoginType, authCode)
+    override fun login(socialLoginType: SocialLoginType, authCode: String, requestOrigin: String): Long {
+        val member = fetchSocialMemberPort.fetchMember(socialLoginType, authCode, requestOrigin)
         val signInMember = findMemberPort.findBySocialIdentifier(member.socialIdentifier)
             ?: saveMemberPort.save(member)
         return signInMember.id
     }
 
-    override fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String {
-        return getSocialLoginUrlPort.getSocialLoginUrl(redirectUrl, socialLoginType)
+    override fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String {
+        return getSocialLoginUrlPort.getSocialLoginUrl(socialLoginType, redirectUrl)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -1,8 +1,10 @@
 package com.celuveat.member.application
 
+import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
 import com.celuveat.member.application.port.out.FindMemberPort
+import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
 import com.celuveat.member.application.port.out.SaveMemberPort
 import com.celuveat.member.domain.SocialLoginType
 import org.springframework.stereotype.Service
@@ -11,9 +13,10 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class SocialLoginService(
     private val fetchSocialMemberPort: FetchSocialMemberPort,
+    private val getSocialLoginUrlPort: GetSocialLoginUrlPort,
     private val saveMemberPort: SaveMemberPort,
     private val findMemberPort: FindMemberPort,
-) : SocialLoginUseCase {
+) : SocialLoginUseCase, GetSocialLoginUrlUseCase {
 
     @Transactional
     override fun login(socialLoginType: SocialLoginType, authCode: String): Long {
@@ -21,5 +24,9 @@ class SocialLoginService(
         val signInMember = findMemberPort.findBySocialIdentifier(member.socialIdentifier)
             ?: saveMemberPort.save(member)
         return signInMember.id
+    }
+
+    override fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String {
+        return getSocialLoginUrlPort.getSocialLoginUrl(redirectUrl, socialLoginType)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/GetSocialLoginUrlUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/GetSocialLoginUrlUseCase.kt
@@ -1,0 +1,8 @@
+package com.celuveat.member.application.port.`in`
+
+import com.celuveat.member.domain.SocialLoginType
+
+interface GetSocialLoginUrlUseCase {
+
+    fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String
+}

--- a/src/main/kotlin/com/celuveat/member/application/port/in/GetSocialLoginUrlUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/GetSocialLoginUrlUseCase.kt
@@ -4,5 +4,5 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface GetSocialLoginUrlUseCase {
 
-    fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String
+    fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/SocialLoginUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/SocialLoginUseCase.kt
@@ -4,5 +4,5 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface SocialLoginUseCase {
 
-    fun login(socialLoginType: SocialLoginType, authCode: String): Long
+    fun login(socialLoginType: SocialLoginType, authCode: String, requestOrigin: String): Long
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/SocialLoginUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/SocialLoginUseCase.kt
@@ -1,8 +1,8 @@
 package com.celuveat.member.application.port.`in`
 
-import com.celuveat.member.domain.SocialLoginType
+import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 
 interface SocialLoginUseCase {
 
-    fun login(socialLoginType: SocialLoginType, authCode: String, requestOrigin: String): Long
+    fun login(command: SocialLoginCommand): Long
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/command/SocialLoginCommand.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/command/SocialLoginCommand.kt
@@ -1,0 +1,9 @@
+package com.celuveat.member.application.port.`in`.command
+
+import com.celuveat.member.domain.SocialLoginType
+
+data class SocialLoginCommand(
+    val socialLoginType: SocialLoginType,
+    val authCode: String,
+    val requestOrigin: String,
+)

--- a/src/main/kotlin/com/celuveat/member/application/port/out/FetchSocialMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/FetchSocialMemberPort.kt
@@ -5,5 +5,5 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface FetchSocialMemberPort {
 
-    fun fetchMember(socialLoginType: SocialLoginType, authCode: String): Member
+    fun fetchMember(socialLoginType: SocialLoginType, authCode: String, redirectUrl: String): Member
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/GetSocialLoginUrlPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/GetSocialLoginUrlPort.kt
@@ -4,5 +4,5 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface GetSocialLoginUrlPort {
 
-    fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String
+    fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/GetSocialLoginUrlPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/GetSocialLoginUrlPort.kt
@@ -1,0 +1,8 @@
+package com.celuveat.member.application.port.out
+
+import com.celuveat.member.domain.SocialLoginType
+
+interface GetSocialLoginUrlPort {
+
+    fun getSocialLoginUrl(redirectUrl: String, socialLoginType: SocialLoginType): String
+}

--- a/src/main/kotlin/com/celuveat/member/exception/SocialExceptions.kt
+++ b/src/main/kotlin/com/celuveat/member/exception/SocialExceptions.kt
@@ -13,3 +13,6 @@ data class NotSupportedSocialLoginTypeException(
     val socialLoginType: SocialLoginType
 ) : SocialException(HttpStatus.NOT_FOUND, "${socialLoginType.name}은 지원하지 않습니다")
 
+data object NotAllowedRedirectUriException : SocialException(HttpStatus.BAD_REQUEST, "허용되지 않은 redirect uri입니다") {
+    private fun readResolve(): Any = NotAllowedRedirectUriException
+}

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -5,6 +5,7 @@ import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.auth.domain.Token
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
+import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 import com.celuveat.member.domain.SocialLoginType
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.FunSpec
@@ -34,7 +35,8 @@ class SocialLoginControllerTest(
         val jwtAccessToken = Token("accessToken")
 
         test("소셜 로그인 성공") {
-            every { socialLoginUseCase.login(socialLoginType, authCode, requestOrigin) } returns 1L
+            val command = SocialLoginCommand(socialLoginType, authCode, requestOrigin)
+            every { socialLoginUseCase.login(command) } returns 1L
             every { createAccessTokenUseCase.create(1L) } returns jwtAccessToken
 
             mockMvc.get("/social-login/login/{socialLoginType}", socialLoginType) {

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -30,14 +30,16 @@ class SocialLoginControllerTest(
     context("OAuth 서비스로부터 받은 인가코드로 로그인을 요청한다") {
         val authCode = "authCode"
         val socialLoginType = SocialLoginType.KAKAO
+        val requestOrigin = "http://localhost:3000"
         val jwtAccessToken = Token("accessToken")
 
         test("소셜 로그인 성공") {
-            every { socialLoginUseCase.login(socialLoginType, authCode) } returns 1L
+            every { socialLoginUseCase.login(socialLoginType, authCode, requestOrigin) } returns 1L
             every { createAccessTokenUseCase.create(1L) } returns jwtAccessToken
 
             mockMvc.get("/social-login/login/{socialLoginType}", socialLoginType) {
                 param("authCode", authCode)
+                header("Origin", requestOrigin)
             }.andExpect {
                 status { isOk() }
                 jsonPath("$.accessToken") { value("accessToken") }
@@ -64,7 +66,7 @@ class SocialLoginControllerTest(
         val socialLoginUrl = "https://social.com/authorize?redirect_uri=$requestOrigin&client_id=clientId"
 
         test("소셜 로그인 URL을 성공적으로 반환한다") {
-            every { getSocialLoginUrlUseCase.getSocialLoginUrl(requestOrigin, socialLoginType) } returns socialLoginUrl
+            every { getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin) } returns socialLoginUrl
 
             mockMvc.get("/social-login/login/{socialLoginType}/url", socialLoginType) {
                 header("Origin", requestOrigin)

--- a/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
@@ -38,6 +38,7 @@ class SocialLoginServiceTest : BehaviorSpec({
 
         val serverType = SocialLoginType.KAKAO
         val socialIdentifier = SocialIdentifier(serverType = serverType, socialId = "socialId")
+        val redirectUrl = "redirectUrl"
         val authCode = "authCode"
 
         val member = sut.giveMeBuilder<Member>()
@@ -47,31 +48,31 @@ class SocialLoginServiceTest : BehaviorSpec({
         val savedMember = member.copy(id = 1L)
 
         When("최초 회원인 경우") {
-            every { fetchSocialMemberPort.fetchMember(serverType, authCode) } returns member
+            every { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) } returns member
             every { findMemberPort.findBySocialIdentifier(socialIdentifier) } returns null
             every { saveMemberPort.save(member) } returns savedMember
 
-            val result = socialLoginService.login(serverType, authCode)
+            val result = socialLoginService.login(serverType, authCode, redirectUrl)
 
             Then("회원가입이 완료된다") {
                 result shouldBe 1L
 
-                verify { fetchSocialMemberPort.fetchMember(serverType, authCode) }
+                verify { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) }
                 verify { findMemberPort.findBySocialIdentifier(socialIdentifier) }
                 verify { saveMemberPort.save(member) }
             }
         }
 
         When("이미 가입된 회원인 경우") {
-            every { fetchSocialMemberPort.fetchMember(serverType, authCode) } returns member
+            every { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) } returns member
             every { findMemberPort.findBySocialIdentifier(socialIdentifier) } returns savedMember
 
-            val result = socialLoginService.login(serverType, authCode)
+            val result = socialLoginService.login(serverType, authCode, redirectUrl)
 
             Then("로그인이 완료된다") {
                 result shouldBe savedMember.id
 
-                verify { fetchSocialMemberPort.fetchMember(serverType, authCode) }
+                verify { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) }
                 verify { findMemberPort.findBySocialIdentifier(socialIdentifier) }
                 verify(exactly = 0) { saveMemberPort.save(member) }
             }
@@ -82,14 +83,14 @@ class SocialLoginServiceTest : BehaviorSpec({
         val serverType = SocialLoginType.KAKAO
         val redirectUrl = "redirectUrl"
         val socialLoginUrl = "https://social.com/authorize?redirect_uri=$redirectUrl&client_id=clientId"
-        every { getSocialLoginUrlPort.getSocialLoginUrl(redirectUrl, serverType) } returns socialLoginUrl
+        every { getSocialLoginUrlPort.getSocialLoginUrl(serverType, redirectUrl) } returns socialLoginUrl
         When("소셜 로그인 타입과 리다이렉트될 URL을 전달하면") {
-            val result = socialLoginService.getSocialLoginUrl(redirectUrl, serverType)
+            val result = socialLoginService.getSocialLoginUrl(serverType, redirectUrl)
 
             Then("소셜 로그인 URL이 반환된다") {
                 result shouldBe socialLoginUrl
 
-                verify { getSocialLoginUrlPort.getSocialLoginUrl(redirectUrl, serverType) }
+                verify { getSocialLoginUrlPort.getSocialLoginUrl(serverType, redirectUrl) }
             }
         }
     }

--- a/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
@@ -1,5 +1,6 @@
 package com.celuveat.member.application
 
+import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
 import com.celuveat.member.application.port.out.FindMemberPort
 import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
@@ -51,9 +52,9 @@ class SocialLoginServiceTest : BehaviorSpec({
             every { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) } returns member
             every { findMemberPort.findBySocialIdentifier(socialIdentifier) } returns null
             every { saveMemberPort.save(member) } returns savedMember
+            val command = SocialLoginCommand(serverType, authCode, redirectUrl)
 
-            val result = socialLoginService.login(serverType, authCode, redirectUrl)
-
+            val result = socialLoginService.login(command)
             Then("회원가입이 완료된다") {
                 result shouldBe 1L
 
@@ -66,9 +67,9 @@ class SocialLoginServiceTest : BehaviorSpec({
         When("이미 가입된 회원인 경우") {
             every { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) } returns member
             every { findMemberPort.findBySocialIdentifier(socialIdentifier) } returns savedMember
+            val command = SocialLoginCommand(serverType, authCode, redirectUrl)
 
-            val result = socialLoginService.login(serverType, authCode, redirectUrl)
-
+            val result = socialLoginService.login(command)
             Then("로그인이 완료된다") {
                 result shouldBe savedMember.id
 


### PR DESCRIPTION
# 관련 태스크
- closed #8 
---

소셜 로그인 타입(kakao, naver, google)에 맞는 로그인 url을 반환하는 API를 개발하였습니다!

고정된 `redirect_url`이 아닌, 허용된 로그인 `redirect_url`에 대해서만 동적으로 authCode 반환경로를 지정할 수 있도록 구성하였습니다.
> 허용 `redriect_urls` 등록 커밋 9b1ec3ce891f3cfb908fecc8906ca9a3148707ae

해당 정보(`redirect_url`)가 포함된 authCode를 활용하여 AccessToken을 요청하게 되는데, 이 경우에도 authCode가 발급된 redirect_uri가 필요하여 수정하였습니다.
```kotlin
private fun fetchAccessToken(authCode: String, redirectUrl: String): GoogleSocialLoginToken {
    val tokenRequestBody = mapOf(
        "grant_type" to "authorization_code",
        "client_id" to googleSocialLoginProperty.clientId,
        "client_secret" to googleSocialLoginProperty.clientSecret,
        "code" to authCode,
        // "redirect_uri" to googleSocialLoginProperty.redirectUri,
        "redirect_uri" to redirectUrl,
    )
    return googleApiClient.fetchToken(tokenRequestBody)
}
```

---
### 건의 사항
login 유즈케이스에서도 redirect_uri 정보가 필요해지면서 파라미터가 3개가 되었는데요.
```kotlin
// val memberId = socialLoginUseCase.login(socialLoginType, authCode)
val memberId = socialLoginUseCase.login(socialLoginType, authCode, requestOrigin)
```
파라미터가 많아졌는데 객체로 감싸면 어떤가요? ex) SocialLoginCommand, SocialLoginRequest, ...