### PR TITLE
chore: klint 추가 & 적용

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,21 @@
 root = true
 
-[*.{kt,kts}]
+[*]
+insert_final_newline = true
+
+[{*.kt,*.kts}]
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+
+#  Disable wildcard imports entirely
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
+ij_kotlin_packages_to_use_import_on_demand = unset
+
 ktlint_standard_package-name = disabled
+ktlint_standard_string-template-indent = disabled
+ktlint_standard_multiline-expression-wrapping = disabled
 
 [src/test/kotlin/**.{kt,kts}]
 ktlint_standard_indent = disabled
 ktlint_standard_string-template-indent = disabled
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.{kt,kts}]
+ktlint_standard_package-name = disabled
+
+[src/test/kotlin/**.{kt,kts}]
+ktlint_standard_indent = disabled
+ktlint_standard_string-template-indent = disabled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
 plugins {
     id("org.springframework.boot") version "3.3.1"
     id("io.spring.dependency-management") version "1.1.5"
+    id("org.jlleitschuh.gradle.ktlint").version("12.1.1")
     kotlin("plugin.jpa") version "1.9.24"
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
@@ -80,4 +83,10 @@ tasks.register("copySecret", Copy::class) {
 // Disable jar task
 tasks.named("jar") {
     enabled = false
+}
+
+ktlint {
+    reporters {
+        reporter(ReporterType.JSON)
+    }
 }

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthMemberArgumentResolver.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthMemberArgumentResolver.kt
@@ -14,17 +14,16 @@ import org.springframework.web.method.support.ModelAndViewContainer
 class AuthMemberArgumentResolver(
     val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : HandlerMethodArgumentResolver {
-
     override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.hasParameterAnnotation(AuthId::class.java)
-                && parameter.parameterType == Long::class.java
+        return parameter.hasParameterAnnotation(AuthId::class.java) &&
+            parameter.parameterType == Long::class.java
     }
 
     override fun resolveArgument(
         parameter: MethodParameter,
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
-        binderFactory: WebDataBinderFactory?
+        binderFactory: WebDataBinderFactory?,
     ): Any? {
         val httpServletRequest = webRequest.toHttpServletRequest()
         val authorization = httpServletRequest.getTokenAuthorizationOrThrow()

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/config/AuthConfiguration.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/config/AuthConfiguration.kt
@@ -9,7 +9,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class AuthConfiguration(
     private val authMemberArgumentResolver: AuthMemberArgumentResolver,
 ) : WebMvcConfigurer {
-
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(authMemberArgumentResolver)
     }

--- a/src/main/kotlin/com/celuveat/auth/adaptor/out/TokenAdaptor.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/out/TokenAdaptor.kt
@@ -16,11 +16,13 @@ import javax.crypto.SecretKey
 class TokenAdaptor(
     tokenProperty: TokenProperty,
 ) : CreateTokenPort, ExtractClaimPort {
-
     private val secretKey: SecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(tokenProperty.secretKey))
     private val accessTokenExpirationMillis: Long = tokenProperty.accessTokenExpirationMillis
 
-    override fun create(key: String, claim: String): Token {
+    override fun create(
+        key: String,
+        claim: String,
+    ): Token {
         return create(mapOf(key to claim))
     }
 
@@ -31,11 +33,14 @@ class TokenAdaptor(
                 .issuedAt(Date())
                 .expiration(Date(System.currentTimeMillis() + accessTokenExpirationMillis))
                 .signWith(secretKey, Jwts.SIG.HS512)
-                .compact()
+                .compact(),
         )
     }
 
-    override fun extract(token: String, key: String): String {
+    override fun extract(
+        token: String,
+        key: String,
+    ): String {
         return extract(token)[key]
             ?: throw NoSuchClaimException(key)
     }

--- a/src/main/kotlin/com/celuveat/auth/adaptor/out/TokenProperty.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/out/TokenProperty.kt
@@ -5,5 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "jwt")
 data class TokenProperty(
     val secretKey: String,
-    val accessTokenExpirationMillis: Long
+    val accessTokenExpirationMillis: Long,
 )

--- a/src/main/kotlin/com/celuveat/auth/application/TokenService.kt
+++ b/src/main/kotlin/com/celuveat/auth/application/TokenService.kt
@@ -10,9 +10,8 @@ import org.springframework.stereotype.Service
 @Service
 class TokenService(
     private val createTokenPort: CreateTokenPort,
-    private val extractClaimPort: ExtractClaimPort
+    private val extractClaimPort: ExtractClaimPort,
 ) : CreateAccessTokenUseCase, ExtractMemberIdUseCase {
-
     override fun create(memberId: Long): Token {
         return createTokenPort.create(MEMBER_ID_CLAIM, memberId.toString())
     }

--- a/src/main/kotlin/com/celuveat/auth/application/port/in/CreateAccessTokenUseCase.kt
+++ b/src/main/kotlin/com/celuveat/auth/application/port/in/CreateAccessTokenUseCase.kt
@@ -3,6 +3,5 @@ package com.celuveat.auth.application.port.`in`
 import com.celuveat.auth.domain.Token
 
 interface CreateAccessTokenUseCase {
-
     fun create(memberId: Long): Token
 }

--- a/src/main/kotlin/com/celuveat/auth/application/port/in/ExtractMemberIdUseCase.kt
+++ b/src/main/kotlin/com/celuveat/auth/application/port/in/ExtractMemberIdUseCase.kt
@@ -1,6 +1,5 @@
 package com.celuveat.auth.application.port.`in`
 
 interface ExtractMemberIdUseCase {
-
     fun extract(token: String): Long
 }

--- a/src/main/kotlin/com/celuveat/auth/application/port/out/CreateTokenPort.kt
+++ b/src/main/kotlin/com/celuveat/auth/application/port/out/CreateTokenPort.kt
@@ -3,7 +3,10 @@ package com.celuveat.auth.application.port.out
 import com.celuveat.auth.domain.Token
 
 interface CreateTokenPort {
+    fun create(
+        key: String,
+        claim: String,
+    ): Token
 
-    fun create(key: String, claim: String): Token
     fun create(claims: Map<String, String>): Token
 }

--- a/src/main/kotlin/com/celuveat/auth/application/port/out/ExtractClaimPort.kt
+++ b/src/main/kotlin/com/celuveat/auth/application/port/out/ExtractClaimPort.kt
@@ -1,7 +1,10 @@
 package com.celuveat.auth.application.port.out
 
 interface ExtractClaimPort {
+    fun extract(
+        token: String,
+        key: String,
+    ): String
 
-    fun extract(token: String, key: String): String
     fun extract(token: String): Map<String, String>
 }

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/JpaConfig.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/JpaConfig.kt
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @EnableJpaAuditing
 @Configuration
-class JpaConfig {
-}
+class JpaConfig

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/RootEntity.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/RootEntity.kt
@@ -2,15 +2,14 @@ package com.celuveat.common.adapter.out.persistence.entity
 
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
-import java.time.LocalDateTime
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class RootEntity<ID> {
-
     @CreatedDate
     lateinit var createdAt: LocalDateTime
 

--- a/src/main/kotlin/com/celuveat/common/annotation/Adapter.kt
+++ b/src/main/kotlin/com/celuveat/common/annotation/Adapter.kt
@@ -2,7 +2,6 @@ package com.celuveat.common.annotation
 
 import org.springframework.stereotype.Component
 
-
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @Component

--- a/src/main/kotlin/com/celuveat/common/annotation/Mapper.kt
+++ b/src/main/kotlin/com/celuveat/common/annotation/Mapper.kt
@@ -2,7 +2,6 @@ package com.celuveat.common.annotation
 
 import org.springframework.stereotype.Component
 
-
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @Component

--- a/src/main/kotlin/com/celuveat/common/exception/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/celuveat/common/exception/ExceptionControllerAdvice.kt
@@ -11,63 +11,68 @@ import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class ExceptionControllerAdvice {
-
     private val log = LoggerFactory.getLogger(ExceptionControllerAdvice::class.java)!!
 
     @ExceptionHandler(CeluveatException::class)
-    fun handleBaseException(request: HttpServletRequest, e: CeluveatException): ResponseEntity<ExceptionResponse> {
+    fun handleBaseException(
+        request: HttpServletRequest,
+        e: CeluveatException,
+    ): ResponseEntity<ExceptionResponse> {
         log.warn(
             """
             잘못된 요청이 들어왔습니다.
             ERROR TYPE: ${e.javaClass.simpleName}
             URI: ${request.requestURI}
             내용: ${e.errorMessage}
-            """
+            """,
         )
         return ResponseEntity.status(e.status).body(
-            ExceptionResponse(e.errorMessage)
+            ExceptionResponse(e.errorMessage),
         )
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
     fun handleConversionFailedException(
         request: HttpServletRequest,
-        e: MethodArgumentTypeMismatchException
+        e: MethodArgumentTypeMismatchException,
     ): ResponseEntity<ExceptionResponse> {
         log.warn(
             """
             잘못된 요청이 들어왔습니다.
             URI: ${request.requestURI}
             내용: ${e.message}
-            """
+            """,
         )
         return ResponseEntity.badRequest().body(
-            ExceptionResponse("잘못된 요청입니다.")
+            ExceptionResponse("잘못된 요청입니다."),
         )
     }
 
     @ExceptionHandler(NoResourceFoundException::class)
     fun handleNoResourceFoundException(
         request: HttpServletRequest,
-        e: NoResourceFoundException
+        e: NoResourceFoundException,
     ): ResponseEntity<ExceptionResponse> {
         log.warn(
             """
             존재하지 않는 리소스에 요청이 들어왔습니다.
             URI: ${request.requestURI}
             내용: ${e.message}
-            """
+            """,
         )
         return ResponseEntity.status(NOT_FOUND).body(
-            ExceptionResponse("요청한 리소스를 찾을 수 없습니다.")
+            ExceptionResponse("요청한 리소스를 찾을 수 없습니다."),
         )
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleException(request: HttpServletRequest, e: Exception): ResponseEntity<ExceptionResponse> {
+    fun handleException(
+        request: HttpServletRequest,
+        e: Exception,
+    ): ResponseEntity<ExceptionResponse> {
         log.error("예상하지 못한 예외가 발생했습니다. URI: ${request.requestURI}, ${e.message}", e)
         return ResponseEntity.internalServerError().body(
-            ExceptionResponse("서버가 응답할 수 없습니다.")
+            ExceptionResponse("서버가 응답할 수 없습니다."),
         )
     }
 }

--- a/src/main/kotlin/com/celuveat/common/utils/ValidationUtils.kt
+++ b/src/main/kotlin/com/celuveat/common/utils/ValidationUtils.kt
@@ -1,5 +1,8 @@
 package com.celuveat.common.utils
 
-inline fun throwWhen(condition: Boolean, exceptionSupplier: () -> RuntimeException) {
+inline fun throwWhen(
+    condition: Boolean,
+    exceptionSupplier: () -> RuntimeException,
+) {
     if (condition) throw exceptionSupplier()
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -22,7 +22,6 @@ class SocialLoginController(
     private val createAccessTokenUseCase: CreateAccessTokenUseCase,
     private val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
 ) {
-
     @GetMapping("/login/{socialLoginType}")
     fun login(
         @PathVariable socialLoginType: SocialLoginType,

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/response/LoginResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/response/LoginResponse.kt
@@ -3,7 +3,7 @@ package com.celuveat.member.adapter.`in`.rest.response
 import com.celuveat.auth.domain.Token
 
 data class LoginResponse(
-    val accessToken: String
+    val accessToken: String,
 ) {
     companion object {
         fun from(token: Token): LoginResponse {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -11,8 +11,11 @@ import com.celuveat.member.exception.NotSupportedSocialLoginTypeException
 class FetchSocialMemberAdapter(
     private val socialLoginClients: Set<SocialLoginClient>,
 ) : FetchSocialMemberPort, GetSocialLoginUrlPort {
-
-    override fun fetchMember(socialLoginType: SocialLoginType, authCode: String, redirectUrl: String): Member {
+    override fun fetchMember(
+        socialLoginType: SocialLoginType,
+        authCode: String,
+        redirectUrl: String,
+    ): Member {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
         return socialLoginClient.fetchMember(authCode, redirectUrl)
     }
@@ -22,7 +25,10 @@ class FetchSocialMemberAdapter(
             ?: throw NotSupportedSocialLoginTypeException(socialLoginType)
     }
 
-    override fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String {
+    override fun getSocialLoginUrl(
+        socialLoginType: SocialLoginType,
+        redirectUrl: String,
+    ): String {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
         return socialLoginClient.getSocialLoginUrl(redirectUrl)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
@@ -5,6 +5,11 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface SocialLoginClient {
     fun isSupports(socialLoginType: SocialLoginType): Boolean
-    fun fetchMember(authCode: String, redirectUrl: String): Member
+
+    fun fetchMember(
+        authCode: String,
+        redirectUrl: String,
+    ): Member
+
     fun getSocialLoginUrl(redirectUrl: String): String
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/config/SocialLoginApiClientConfig.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/config/SocialLoginApiClientConfig.kt
@@ -11,7 +11,6 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.support.RestClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 
-
 @Configuration
 class SocialLoginApiClientConfig {
     private val log = LoggerFactory.getLogger(this.javaClass)!!
@@ -34,7 +33,7 @@ class SocialLoginApiClientConfig {
     private fun <T> createHttpInterface(clazz: Class<T>): T {
         val restClient = buildRestClientWithStatusHandler()
         return HttpServiceProxyFactory.builderFor(
-            RestClientAdapter.create(restClient)
+            RestClientAdapter.create(restClient),
         ).build().createClient(clazz)
     }
 
@@ -45,13 +44,15 @@ class SocialLoginApiClientConfig {
                 { _, response ->
                     log.error("Client Error Code={}", response.statusCode)
                     log.error("Client Error Message={}", String(response.body.readAllBytes()))
-                })
+                },
+            )
             .defaultStatusHandler(
                 { status: HttpStatusCode -> status.is5xxServerError },
                 { _, response ->
                     log.error("External Api Server Error Code={}", response.statusCode)
                     log.error("External Api Server Error Message={}", String(response.body.readAllBytes()))
-                })
+                },
+            )
             .build()
         return restClient
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleApiClient.kt
@@ -8,13 +8,14 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.PostExchange
 
-
 interface GoogleApiClient {
-
     @PostExchange(url = "https://oauth2.googleapis.com/token")
-    fun fetchToken(@RequestParam params: Map<String, String>): GoogleSocialLoginToken
+    fun fetchToken(
+        @RequestParam params: Map<String, String>,
+    ): GoogleSocialLoginToken
 
-    
     @GetExchange("https://www.googleapis.com/oauth2/v2/userinfo")
-    fun fetchMemberInfo(@RequestHeader(AUTHORIZATION) bearerToken: String): GoogleMemberInfoResponse
+    fun fetchMemberInfo(
+        @RequestHeader(AUTHORIZATION) bearerToken: String,
+    ): GoogleMemberInfoResponse
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -16,12 +16,14 @@ class GoogleSocialLoginClient(
     private val googleSocialLoginProperty: GoogleSocialLoginProperty,
     private val googleApiClient: GoogleApiClient,
 ) : SocialLoginClient {
-
     override fun isSupports(socialLoginType: SocialLoginType): Boolean {
         return socialLoginType == SocialLoginType.GOOGLE
     }
 
-    override fun fetchMember(authCode: String, redirectUrl: String): Member {
+    override fun fetchMember(
+        authCode: String,
+        redirectUrl: String,
+    ): Member {
         validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
@@ -32,7 +34,10 @@ class GoogleSocialLoginClient(
         throwWhen(allowedRedirectUris.doesNotContain(redirectUrl)) { NotAllowedRedirectUriException }
     }
 
-    private fun fetchAccessToken(authCode: String, redirectUrl: String): GoogleSocialLoginToken {
+    private fun fetchAccessToken(
+        authCode: String,
+        redirectUrl: String,
+    ): GoogleSocialLoginToken {
         val tokenRequestBody = mapOf(
             "grant_type" to "authorization_code",
             "client_id" to googleSocialLoginProperty.clientId,

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginProperty.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginProperty.kt
@@ -9,5 +9,4 @@ data class GoogleSocialLoginProperty(
     val clientSecret: String,
     val scope: List<String>,
     val authorizationUrl: String = "https://accounts.google.com/o/oauth2/v2/auth",
-) {
-}
+)

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/response/GoogleMemberInfoResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/response/GoogleMemberInfoResponse.kt
@@ -14,7 +14,6 @@ data class GoogleMemberInfoResponse(
     private val picture: String,
     private val locale: String,
 ) {
-
     fun toMember(): Member {
         return Member(
             nickname = name,
@@ -22,7 +21,7 @@ data class GoogleMemberInfoResponse(
             socialIdentifier = SocialIdentifier(
                 serverType = SocialLoginType.GOOGLE,
                 socialId = id,
-            )
+            ),
         )
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/response/GoogleSocialLoginToken.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/response/GoogleSocialLoginToken.kt
@@ -9,5 +9,5 @@ data class GoogleSocialLoginToken(
     val refreshToken: String,
     val expiresIn: Int,
     val tokenType: String,
-    val scope: String
+    val scope: String,
 )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoApiClient.kt
@@ -10,12 +10,15 @@ import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.PostExchange
 
 interface KakaoApiClient {
-
     // ref - https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
     @PostExchange(url = "https://kauth.kakao.com/oauth/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
-    fun fetchToken(@RequestParam body: Map<String, String>): KakaoSocialLoginToken
+    fun fetchToken(
+        @RequestParam body: Map<String, String>,
+    ): KakaoSocialLoginToken
 
     // ref - https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info-response
     @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
-    fun fetchMemberInfo(@RequestHeader(name = AUTHORIZATION) bearerToken: String): KakaoMemberInfoResponse
+    fun fetchMemberInfo(
+        @RequestHeader(name = AUTHORIZATION) bearerToken: String,
+    ): KakaoMemberInfoResponse
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -16,12 +16,14 @@ class KakaoSocialLoginClient(
     private val kakaoSocialLoginProperty: KakaoSocialLoginProperty,
     private val kakaoApiClient: KakaoApiClient,
 ) : SocialLoginClient {
-
     override fun isSupports(socialLoginType: SocialLoginType): Boolean {
         return socialLoginType == SocialLoginType.KAKAO
     }
 
-    override fun fetchMember(authCode: String, redirectUrl: String): Member {
+    override fun fetchMember(
+        authCode: String,
+        redirectUrl: String,
+    ): Member {
         validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
@@ -32,13 +34,16 @@ class KakaoSocialLoginClient(
         throwWhen(allowedRedirectUris.doesNotContain(redirectUrl)) { NotAllowedRedirectUriException }
     }
 
-    private fun fetchAccessToken(authCode: String, redirectUrl: String): KakaoSocialLoginToken {
+    private fun fetchAccessToken(
+        authCode: String,
+        redirectUrl: String,
+    ): KakaoSocialLoginToken {
         val tokenRequestBody = mapOf(
             "grant_type" to "authorization_code",
             "client_id" to kakaoSocialLoginProperty.clientId,
             "redirect_uri" to redirectUrl,
             "code" to authCode,
-            "client_secret" to kakaoSocialLoginProperty.clientSecret
+            "client_secret" to kakaoSocialLoginProperty.clientSecret,
         )
         return kakaoApiClient.fetchToken(tokenRequestBody)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/response/KakaoMemberInfoResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/response/KakaoMemberInfoResponse.kt
@@ -11,7 +11,6 @@ data class KakaoMemberInfoResponse(
     private val id: String,
     private val kakaoAccount: KakaoAccount,
 ) {
-
     fun toMember(): Member {
         return Member(
             nickname = kakaoAccount.profile.nickname,
@@ -19,7 +18,7 @@ data class KakaoMemberInfoResponse(
             socialIdentifier = SocialIdentifier(
                 serverType = SocialLoginType.KAKAO,
                 socialId = id,
-            )
+            ),
         )
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/response/KakaoSocialLoginToken.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/response/KakaoSocialLoginToken.kt
@@ -9,5 +9,5 @@ data class KakaoSocialLoginToken(
     val refreshToken: String,
     val expiresIn: Int,
     val tokenType: String,
-    val refreshTokenExpiresIn: Int
+    val refreshTokenExpiresIn: Int,
 )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverApiClient.kt
@@ -9,12 +9,15 @@ import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.PostExchange
 
 interface NaverApiClient {
-
     // ref - https://developers.naver.com/docs/login/api/api.md
     @PostExchange(url = "https://nid.naver.com/oauth2.0/token")
-    fun fetchToken(@RequestParam params: Map<String, String>): NaverSocialLoginToken
+    fun fetchToken(
+        @RequestParam params: Map<String, String>,
+    ): NaverSocialLoginToken
 
     // ref - https://developers.naver.com/docs/login/profile/profile.md
     @GetExchange("https://openapi.naver.com/v1/nid/me")
-    fun fetchMemberInfo(@RequestHeader(name = AUTHORIZATION) bearerToken: String): NaverMemberInfoResponse
+    fun fetchMemberInfo(
+        @RequestHeader(name = AUTHORIZATION) bearerToken: String,
+    ): NaverMemberInfoResponse
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -16,12 +16,14 @@ class NaverSocialLoginClient(
     private val naverSocialLoginProperty: NaverSocialLoginProperty,
     private val naverApiClient: NaverApiClient,
 ) : SocialLoginClient {
-
     override fun isSupports(socialLoginType: SocialLoginType): Boolean {
         return socialLoginType == SocialLoginType.NAVER
     }
 
-    override fun fetchMember(authCode: String, redirectUrl: String): Member {
+    override fun fetchMember(
+        authCode: String,
+        redirectUrl: String,
+    ): Member {
         validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode)
         return fetchMemberInfo(socialLoginToken.accessToken).toMember()
@@ -38,7 +40,7 @@ class NaverSocialLoginClient(
             "client_id" to naverSocialLoginProperty.clientId,
             "client_secret" to naverSocialLoginProperty.clientSecret,
             "code" to authCode,
-            "state" to naverSocialLoginProperty.state
+            "state" to naverSocialLoginProperty.state,
         )
         return naverApiClient.fetchToken(tokenRequestBody)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/response/NaverMemberInfoResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/response/NaverMemberInfoResponse.kt
@@ -10,9 +10,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 data class NaverMemberInfoResponse(
     private val resultcode: String,
     private val message: String,
-    private val response: Response
+    private val response: Response,
 ) {
-
     fun toMember(): Member {
         return Member(
             nickname = response.nickname,
@@ -20,7 +19,7 @@ data class NaverMemberInfoResponse(
             socialIdentifier = SocialIdentifier(
                 serverType = SocialLoginType.NAVER,
                 socialId = response.id,
-            )
+            ),
         )
     }
 }
@@ -36,5 +35,5 @@ data class Response(
     val birthday: String,
     val profileImage: String,
     val birthyear: String,
-    val mobile: String
+    val mobile: String,
 )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/response/NaverSocialLoginToken.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/response/NaverSocialLoginToken.kt
@@ -5,5 +5,5 @@ data class NaverSocialLoginToken(
     val refreshToken: String,
     val tokenType: String,
     val error: String,
-    val errorDescription: String
+    val errorDescription: String,
 )

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/MemberPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/MemberPersistenceAdapter.kt
@@ -13,11 +13,10 @@ class MemberPersistenceAdapter(
     private val memberJpaRepository: MemberJpaRepository,
     private val memberPersistenceMapper: MemberPersistenceMapper,
 ) : SaveMemberPort, FindMemberPort {
-
     override fun findBySocialIdentifier(socialIdentifier: SocialIdentifier): Member? {
         return memberJpaRepository.findMemberBySocialIdAndServerType(
             socialIdentifier.socialId,
-            socialIdentifier.serverType
+            socialIdentifier.serverType,
         )?.let { memberPersistenceMapper.toDomain(it) }
     }
 

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaEntity.kt
@@ -15,12 +15,10 @@ class MemberJpaEntity(
     val id: Long = 0,
     val nickname: String,
     val profileImageUrl: String?,
-
     @Enumerated(EnumType.STRING)
     val serverType: SocialLoginType,
     val socialId: String,
 ) : RootEntity<Long>() {
-
     override fun id(): Long {
         return this.id
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaRepository.kt
@@ -4,6 +4,8 @@ import com.celuveat.member.domain.SocialLoginType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberJpaRepository : JpaRepository<MemberJpaEntity, Long> {
-
-    fun findMemberBySocialIdAndServerType(socialId: String, oAuthServerType: SocialLoginType): MemberJpaEntity?
+    fun findMemberBySocialIdAndServerType(
+        socialId: String,
+        oAuthServerType: SocialLoginType,
+    ): MemberJpaEntity?
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberPersistenceMapper.kt
@@ -6,7 +6,6 @@ import com.celuveat.member.domain.SocialIdentifier
 
 @Mapper
 class MemberPersistenceMapper {
-
     fun toEntity(member: Member): MemberJpaEntity {
         return MemberJpaEntity(
             id = member.id,
@@ -25,7 +24,7 @@ class MemberPersistenceMapper {
             socialIdentifier = SocialIdentifier(
                 serverType = memberJpaEntity.serverType,
                 socialId = memberJpaEntity.socialId,
-            )
+            ),
         )
     }
 }

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -18,7 +18,6 @@ class SocialLoginService(
     private val saveMemberPort: SaveMemberPort,
     private val findMemberPort: FindMemberPort,
 ) : SocialLoginUseCase, GetSocialLoginUrlUseCase {
-
     @Transactional
     override fun login(command: SocialLoginCommand): Long {
         val member = fetchSocialMemberPort.fetchMember(
@@ -31,7 +30,10 @@ class SocialLoginService(
         return signInMember.id
     }
 
-    override fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String {
+    override fun getSocialLoginUrl(
+        socialLoginType: SocialLoginType,
+        redirectUrl: String,
+    ): String {
         return getSocialLoginUrlPort.getSocialLoginUrl(socialLoginType, redirectUrl)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/GetSocialLoginUrlUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/GetSocialLoginUrlUseCase.kt
@@ -3,6 +3,8 @@ package com.celuveat.member.application.port.`in`
 import com.celuveat.member.domain.SocialLoginType
 
 interface GetSocialLoginUrlUseCase {
-
-    fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String
+    fun getSocialLoginUrl(
+        socialLoginType: SocialLoginType,
+        redirectUrl: String,
+    ): String
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/SocialLoginUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/SocialLoginUseCase.kt
@@ -3,6 +3,5 @@ package com.celuveat.member.application.port.`in`
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 
 interface SocialLoginUseCase {
-
     fun login(command: SocialLoginCommand): Long
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/FetchSocialMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/FetchSocialMemberPort.kt
@@ -4,6 +4,9 @@ import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
 
 interface FetchSocialMemberPort {
-
-    fun fetchMember(socialLoginType: SocialLoginType, authCode: String, redirectUrl: String): Member
+    fun fetchMember(
+        socialLoginType: SocialLoginType,
+        authCode: String,
+        redirectUrl: String,
+    ): Member
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/FindMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/FindMemberPort.kt
@@ -4,6 +4,5 @@ import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialIdentifier
 
 interface FindMemberPort {
-
     fun findBySocialIdentifier(socialIdentifier: SocialIdentifier): Member?
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/GetSocialLoginUrlPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/GetSocialLoginUrlPort.kt
@@ -3,6 +3,8 @@ package com.celuveat.member.application.port.out
 import com.celuveat.member.domain.SocialLoginType
 
 interface GetSocialLoginUrlPort {
-
-    fun getSocialLoginUrl(socialLoginType: SocialLoginType, redirectUrl: String): String
+    fun getSocialLoginUrl(
+        socialLoginType: SocialLoginType,
+        redirectUrl: String,
+    ): String
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/SaveMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/SaveMemberPort.kt
@@ -3,6 +3,5 @@ package com.celuveat.member.application.port.out
 import com.celuveat.member.domain.Member
 
 interface SaveMemberPort {
-
     fun save(member: Member): Member
 }

--- a/src/main/kotlin/com/celuveat/member/domain/SocialLoginType.kt
+++ b/src/main/kotlin/com/celuveat/member/domain/SocialLoginType.kt
@@ -4,5 +4,4 @@ enum class SocialLoginType {
     KAKAO,
     NAVER,
     GOOGLE,
-    ;
 }

--- a/src/main/kotlin/com/celuveat/member/exception/SocialExceptions.kt
+++ b/src/main/kotlin/com/celuveat/member/exception/SocialExceptions.kt
@@ -10,7 +10,7 @@ sealed class SocialException(
 ) : CeluveatException(status, errorMessage)
 
 data class NotSupportedSocialLoginTypeException(
-    val socialLoginType: SocialLoginType
+    val socialLoginType: SocialLoginType,
 ) : SocialException(HttpStatus.NOT_FOUND, "${socialLoginType.name}은 지원하지 않습니다")
 
 data object NotAllowedRedirectUriException : SocialException(HttpStatus.BAD_REQUEST, "허용되지 않은 redirect uri입니다") {

--- a/src/main/kotlin/com/celuveat/sample/adapter/in/rest/SampleController.kt
+++ b/src/main/kotlin/com/celuveat/sample/adapter/in/rest/SampleController.kt
@@ -2,19 +2,20 @@ package com.celuveat.sample.adapter.`in`.rest
 
 import com.celuveat.sample.adapter.`in`.rest.request.SaveSampleRequest
 import com.celuveat.sample.application.port.`in`.SaveSampleUseCase
-import java.net.URI
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
+import java.net.URI
 
 @Controller
 class SampleController(
     val saveSampleUseCase: SaveSampleUseCase,
 ) {
-
     @GetMapping("/sample")
-    fun sample(@RequestBody request: SaveSampleRequest): ResponseEntity<Long> {
+    fun sample(
+        @RequestBody request: SaveSampleRequest,
+    ): ResponseEntity<Long> {
         val command = request.toCommand()
         val sample = saveSampleUseCase.saveSample(command)
         return ResponseEntity.created(URI.create("/sample/${sample.id}")).build()

--- a/src/main/kotlin/com/celuveat/sample/adapter/in/rest/request/SaveSampleRequest.kt
+++ b/src/main/kotlin/com/celuveat/sample/adapter/in/rest/request/SaveSampleRequest.kt
@@ -5,7 +5,6 @@ import com.celuveat.sample.application.port.`in`.command.SaveSampleCommand
 data class SaveSampleRequest(
     val name: String,
 ) {
-
     fun toCommand(): SaveSampleCommand {
         return SaveSampleCommand(name)
     }

--- a/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/SamplePersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/SamplePersistenceAdapter.kt
@@ -10,8 +10,7 @@ import com.celuveat.sample.domain.Sample
 class SamplePersistenceAdapter(
     private val mapper: SamplePersistenceMapper,
     private val sampleJpaRepository: SampleJpaRepository,
-): SaveSamplePort {
-
+) : SaveSamplePort {
     override fun save(sample: Sample): Sample {
         val sampleEntity = mapper.toEntity(sample)
         val saved = sampleJpaRepository.save(sampleEntity)

--- a/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/entity/SampleJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/entity/SampleJpaEntity.kt
@@ -10,5 +10,4 @@ class SampleJpaEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L,
     var name: String,
-) {
-}
+)

--- a/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/entity/SampleJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/entity/SampleJpaRepository.kt
@@ -2,5 +2,4 @@ package com.celuveat.sample.adapter.out.persistence.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface SampleJpaRepository : JpaRepository<SampleJpaEntity, Long> {
-}
+interface SampleJpaRepository : JpaRepository<SampleJpaEntity, Long>

--- a/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/entity/SamplePersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/sample/adapter/out/persistence/entity/SamplePersistenceMapper.kt
@@ -5,7 +5,6 @@ import com.celuveat.sample.domain.Sample
 
 @Mapper
 class SamplePersistenceMapper {
-
     fun toEntity(sample: Sample): SampleJpaEntity {
         return SampleJpaEntity(
             id = sample.id,

--- a/src/main/kotlin/com/celuveat/sample/application/SampleService.kt
+++ b/src/main/kotlin/com/celuveat/sample/application/SampleService.kt
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service
 class SampleService(
     private val saveSamplePort: SaveSamplePort,
 ) : SaveSampleUseCase {
-
     override fun saveSample(command: SaveSampleCommand): Sample {
         return saveSamplePort.save(command.toSample())
     }

--- a/src/main/kotlin/com/celuveat/sample/application/port/in/SaveSampleUseCase.kt
+++ b/src/main/kotlin/com/celuveat/sample/application/port/in/SaveSampleUseCase.kt
@@ -4,6 +4,5 @@ import com.celuveat.sample.application.port.`in`.command.SaveSampleCommand
 import com.celuveat.sample.domain.Sample
 
 interface SaveSampleUseCase {
-
     fun saveSample(command: SaveSampleCommand): Sample
 }

--- a/src/main/kotlin/com/celuveat/sample/application/port/out/SaveSamplePort.kt
+++ b/src/main/kotlin/com/celuveat/sample/application/port/out/SaveSamplePort.kt
@@ -3,6 +3,5 @@ package com.celuveat.sample.application.port.out
 import com.celuveat.sample.domain.Sample
 
 interface SaveSamplePort {
-
     fun save(sample: Sample): Sample
 }

--- a/src/test/kotlin/com/celuveat/CeluveatApplicationTests.kt
+++ b/src/test/kotlin/com/celuveat/CeluveatApplicationTests.kt
@@ -5,9 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class CeluveatApplicationTests {
-
     @Test
     fun contextLoads() {
     }
-
 }

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -25,7 +25,8 @@ class SocialLoginControllerTest(
     @MockkBean val socialLoginUseCase: SocialLoginUseCase,
     @MockkBean val createAccessTokenUseCase: CreateAccessTokenUseCase,
     @MockkBean val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
-    @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase, // for AuthMemberArgumentResolver
+    // for AuthMemberArgumentResolver
+    @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({
 
     context("OAuth 서비스로부터 받은 인가코드로 로그인을 요청한다") {
@@ -90,8 +91,10 @@ class SocialLoginControllerTest(
         }
     }
 }) {
-
-    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+    override suspend fun afterEach(
+        testCase: TestCase,
+        result: TestResult,
+    ) {
         clearAllMocks()
         unmockkAll()
     }

--- a/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
@@ -96,8 +96,10 @@ class SocialLoginServiceTest : BehaviorSpec({
         }
     }
 }) {
-
-    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+    override suspend fun afterEach(
+        testCase: TestCase,
+        result: TestResult,
+    ) {
         clearAllMocks()
         unmockkAll()
     }


### PR DESCRIPTION
# 관련 태스크
- closed #11 
---
ktlint 설정을 추가하였습니다!
gradle에 몇가지 task들이 추가되었어요.
![image](https://github.com/user-attachments/assets/0d67227c-c326-44bd-927b-19b1f771311b)

기본적으로 kotlin 컨벤션을 기반으로 검사합니다.
- `ktlintCheck`는 검사 수행
- `ktlintFormat`은 자동으로 수정

그리고 build시에도 `ktlintCheck`가 자동으로 수행 되어요!

---
`.editorconfig`에서 몇가지 rule을 수정할 수 있습니다.
3가지 rule을 비활성화 했습니다.

## 1. ktlint_standard_package-name
`in` 패키지의 경우 kotlin예악어랑 겹쳐서 \`in\` <- 이렇게 사용 되는데 이부분이 패키지 네이밍 컨벤션에 걸립니다.
```kotlin
import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
```
패키지는 쉽게 확인 가능하고 양도 적어서 lint에서 비활성화 해두었습니다!

## 2. ktlint_standard_indent
Ko-test 스타일로 태스트를 하다보니 indent가 많이 존재 할 수 밖에 없는데
```kotlin
class SocialLoginControllerTest(
// ...
) : FunSpec({

    context("OAuth 서비스로부터 받은 인가코드로 로그인을 요청한다") {
       // ...
        test("소셜 로그인 성공") {
            mockMvc.get() {
            }.andExpect {
            }.andDo {
                print()
            }
        }
    }
}
```
이 뎁스가 컨벤션에 걸려서 통과가 안되더라고요.
`.editorconfig`에서 test에 대해서만 인덴트 rule을 비활성화 해두었습니다.

## 3. ktlint_standard_multiline-expression-wrapping
[ktlint에서 적용되어 있는 rule](https://pinterest.github.io/ktlint/latest/rules/standard/#multiline-expression-wrapping)입니다.
```kotlin
// rule 적용
val socialLoginService =
    SocialLoginService(
        fetchSocialMemberPort = fetchSocialMemberPort,
        saveMemberPort = saveMemberPort,
        findMemberPort = findMemberPort,
        getSocialLoginUrlPort = getSocialLoginUrlPort,
    )

// 미적용
val socialLoginService = SocialLoginService(
    fetchSocialMemberPort = fetchSocialMemberPort,
    saveMemberPort = saveMemberPort,
    findMemberPort = findMemberPort,
    getSocialLoginUrlPort = getSocialLoginUrlPort,
)
```
위 예시에서 처럼, 적용하지 않는게 (현재 컨벤션) 더 가독성 있어 보여서 비활성화 해두었습니다.

컨벤션 설정과 관련하여 의견 있으시면 남겨주세요!
---

ktlint 사용 & 적용하면서 학습했던 내용들 블로깅 했는데 한번 읽어보시면 도움 될 것 같아요!!
[SpringBoot - Kotlin 프로젝트에 Klint 적용 및 disable 설정](
https://velog.io/@roycewon/SpringBoot-Kotlin-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EC%97%90-Klint-%EC%A0%81%EC%9A%A9-%EB%B0%8F-disable-%EC%84%A4%EC%A0%95)