### PR TITLE
feat: 회원 탈퇴 api

### DIFF
--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -50,7 +50,6 @@ class SocialLoginController(
         response.sendRedirect(socialLoginUrl)
     }
 
-
     @DeleteMapping("/withdraw/{socialLoginType}")
     fun withdraw(
         @AuthId memberId: Long,

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -40,7 +40,7 @@ class SocialLoginController(
         return LoginResponse.from(token)
     }
 
-    @GetMapping("/{socialLoginType}/url")
+    @GetMapping("/url/{socialLoginType}")
     fun redirectLoginUrl(
         @PathVariable socialLoginType: SocialLoginType,
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -22,7 +22,7 @@ class SocialLoginController(
     private val createAccessTokenUseCase: CreateAccessTokenUseCase,
     private val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
 ) {
-    @GetMapping("/login/{socialLoginType}")
+    @GetMapping("/{socialLoginType}")
     fun login(
         @PathVariable socialLoginType: SocialLoginType,
         @RequestParam authCode: String,
@@ -34,7 +34,7 @@ class SocialLoginController(
         return LoginResponse.from(token)
     }
 
-    @GetMapping("/login/{socialLoginType}/url")
+    @GetMapping("/{socialLoginType}/url")
     fun redirectLoginUrl(
         @PathVariable socialLoginType: SocialLoginType,
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -1,13 +1,18 @@
 package com.celuveat.member.adapter.`in`.rest
 
+import com.celuveat.auth.adaptor.`in`.rest.AuthId
 import com.celuveat.auth.application.port.`in`.CreateAccessTokenUseCase
 import com.celuveat.member.adapter.`in`.rest.response.LoginResponse
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
+import com.celuveat.member.application.port.`in`.WithdrawSocialLoginUseCase
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
+import com.celuveat.member.application.port.`in`.command.WithdrawSocialLoginCommand
 import com.celuveat.member.domain.SocialLoginType
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
@@ -21,6 +26,7 @@ class SocialLoginController(
     private val socialLoginUseCase: SocialLoginUseCase,
     private val createAccessTokenUseCase: CreateAccessTokenUseCase,
     private val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
+    private val withdrawSocialLoginUseCase: WithdrawSocialLoginUseCase,
 ) {
     @GetMapping("/{socialLoginType}")
     fun login(
@@ -42,5 +48,18 @@ class SocialLoginController(
     ) {
         val socialLoginUrl = getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin)
         response.sendRedirect(socialLoginUrl)
+    }
+
+
+    @DeleteMapping("/withdraw/{socialLoginType}")
+    fun withdraw(
+        @AuthId memberId: Long,
+        @RequestParam authCode: String,
+        @PathVariable socialLoginType: SocialLoginType,
+        @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
+    ): ResponseEntity<Unit> {
+        val command = WithdrawSocialLoginCommand(memberId, authCode, socialLoginType, requestOrigin)
+        withdrawSocialLoginUseCase.withdraw(command)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -3,6 +3,7 @@ package com.celuveat.member.adapter.out.oauth
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
 import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
+import com.celuveat.member.application.port.out.WithdrawSocialMemberPort
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
 import com.celuveat.member.exception.NotSupportedSocialLoginTypeException
@@ -10,7 +11,7 @@ import com.celuveat.member.exception.NotSupportedSocialLoginTypeException
 @Adapter
 class FetchSocialMemberAdapter(
     private val socialLoginClients: Set<SocialLoginClient>,
-) : FetchSocialMemberPort, GetSocialLoginUrlPort {
+) : FetchSocialMemberPort, GetSocialLoginUrlPort, WithdrawSocialMemberPort {
     override fun fetchMember(
         socialLoginType: SocialLoginType,
         authCode: String,
@@ -31,5 +32,14 @@ class FetchSocialMemberAdapter(
     ): String {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
         return socialLoginClient.getSocialLoginUrl(redirectUrl)
+    }
+
+    override fun withdraw(
+        authCode: String,
+        socialLoginType: SocialLoginType,
+        redirectUrl: String
+    ) {
+        val socialLoginClient = getSocialLoginClient(socialLoginType)
+        socialLoginClient.withdraw(authCode, redirectUrl)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -37,7 +37,7 @@ class FetchSocialMemberAdapter(
     override fun withdraw(
         authCode: String,
         socialLoginType: SocialLoginType,
-        redirectUrl: String
+        redirectUrl: String,
     ) {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
         socialLoginClient.withdraw(authCode, redirectUrl)

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
@@ -13,5 +13,8 @@ interface SocialLoginClient {
 
     fun getSocialLoginUrl(redirectUrl: String): String
 
-    fun withdraw(authCode: String, redirectUrl: String)
+    fun withdraw(
+        authCode: String,
+        redirectUrl: String,
+    )
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
@@ -12,4 +12,6 @@ interface SocialLoginClient {
     ): Member
 
     fun getSocialLoginUrl(redirectUrl: String): String
+
+    fun withdraw(authCode: String, redirectUrl: String)
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleApiClient.kt
@@ -18,4 +18,10 @@ interface GoogleApiClient {
     fun fetchMemberInfo(
         @RequestHeader(AUTHORIZATION) bearerToken: String,
     ): GoogleMemberInfoResponse
+
+    // ref - https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke
+    @PostExchange("https://oauth2.googleapis.com/revoke")
+    fun withdraw(
+        @RequestParam token: String,
+    )
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -62,4 +62,9 @@ class GoogleSocialLoginClient(
             .build()
             .toUriString()
     }
+
+    override fun withdraw(authCode: String, redirectUrl: String) {
+        val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
+        googleApiClient.withdraw(socialLoginToken.accessToken)
+    }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -63,7 +63,10 @@ class GoogleSocialLoginClient(
             .toUriString()
     }
 
-    override fun withdraw(authCode: String, redirectUrl: String) {
+    override fun withdraw(
+        authCode: String,
+        redirectUrl: String,
+    ) {
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         googleApiClient.withdraw(socialLoginToken.accessToken)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoApiClient.kt
@@ -21,4 +21,10 @@ interface KakaoApiClient {
     fun fetchMemberInfo(
         @RequestHeader(name = AUTHORIZATION) bearerToken: String,
     ): KakaoMemberInfoResponse
+
+    // ref - https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink
+    @PostExchange(url = "https://kapi.kakao.com/v1/user/unlink", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+    fun withdraw(
+        @RequestHeader(name = AUTHORIZATION) bearerToken: String,
+    )
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -63,7 +63,10 @@ class KakaoSocialLoginClient(
             .toUriString()
     }
 
-    override fun withdraw(authCode: String, redirectUrl: String) {
+    override fun withdraw(
+        authCode: String,
+        redirectUrl: String,
+    ) {
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
         kakaoApiClient.withdraw("Bearer ${socialLoginToken.accessToken}")
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -62,4 +62,9 @@ class KakaoSocialLoginClient(
             .build()
             .toUriString()
     }
+
+    override fun withdraw(authCode: String, redirectUrl: String) {
+        val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
+        kakaoApiClient.withdraw("Bearer ${socialLoginToken.accessToken}")
+    }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverApiClient.kt
@@ -20,4 +20,10 @@ interface NaverApiClient {
     fun fetchMemberInfo(
         @RequestHeader(name = AUTHORIZATION) bearerToken: String,
     ): NaverMemberInfoResponse
+
+    // ref - https://developers.naver.com/docs/login/devguide/devguide.md#5-3-%EB%84%A4%EC%9D%B4%EB%B2%84-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%97%B0%EB%8F%99-%ED%95%B4%EC%A0%9C
+    @PostExchange("https://nid.naver.com/oauth2.0/token")
+    fun withdraw(
+        @RequestParam params: Map<String, String>,
+    )
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -60,7 +60,10 @@ class NaverSocialLoginClient(
             .toUriString()
     }
 
-    override fun withdraw(authCode: String, redirectUrl: String) {
+    override fun withdraw(
+        authCode: String,
+        redirectUrl: String,
+    ) {
         val accessToken = fetchAccessToken(authCode)
         val tokenRequestBody = mapOf(
             "client_id" to naverSocialLoginProperty.clientId,

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -59,4 +59,15 @@ class NaverSocialLoginClient(
             .build()
             .toUriString()
     }
+
+    override fun withdraw(authCode: String, redirectUrl: String) {
+        val accessToken = fetchAccessToken(authCode)
+        val tokenRequestBody = mapOf(
+            "client_id" to naverSocialLoginProperty.clientId,
+            "client_secret" to naverSocialLoginProperty.clientSecret,
+            "access_token" to accessToken.accessToken,
+            "grant_type" to "delete",
+        )
+        naverApiClient.withdraw(tokenRequestBody)
+    }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/MemberPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/MemberPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package com.celuveat.member.adapter.out.persistence
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
 import com.celuveat.member.adapter.out.persistence.entity.MemberPersistenceMapper
+import com.celuveat.member.application.port.out.DeleteMemberPort
 import com.celuveat.member.application.port.out.FindMemberPort
 import com.celuveat.member.application.port.out.SaveMemberPort
 import com.celuveat.member.domain.Member
@@ -12,7 +13,7 @@ import com.celuveat.member.domain.SocialIdentifier
 class MemberPersistenceAdapter(
     private val memberJpaRepository: MemberJpaRepository,
     private val memberPersistenceMapper: MemberPersistenceMapper,
-) : SaveMemberPort, FindMemberPort {
+) : SaveMemberPort, FindMemberPort, DeleteMemberPort {
     override fun findBySocialIdentifier(socialIdentifier: SocialIdentifier): Member? {
         return memberJpaRepository.findMemberBySocialIdAndServerType(
             socialIdentifier.socialId,
@@ -24,5 +25,9 @@ class MemberPersistenceAdapter(
         val memberEntity = memberPersistenceMapper.toEntity(member)
         val saveMember = memberJpaRepository.save(memberEntity)
         return memberPersistenceMapper.toDomain(saveMember)
+    }
+
+    override fun deleteById(memberId: Long) {
+        memberJpaRepository.deleteById(memberId)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -43,6 +43,7 @@ class SocialLoginService(
         return getSocialLoginUrlPort.getSocialLoginUrl(socialLoginType, redirectUrl)
     }
 
+    @Transactional
     override fun withdraw(command: WithdrawSocialLoginCommand) {
         withdrawSocialMemberPort.withdraw(
             command.authCode,

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -2,11 +2,15 @@ package com.celuveat.member.application
 
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
+import com.celuveat.member.application.port.`in`.WithdrawSocialLoginUseCase
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
+import com.celuveat.member.application.port.`in`.command.WithdrawSocialLoginCommand
+import com.celuveat.member.application.port.out.DeleteMemberPort
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
 import com.celuveat.member.application.port.out.FindMemberPort
 import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
 import com.celuveat.member.application.port.out.SaveMemberPort
+import com.celuveat.member.application.port.out.WithdrawSocialMemberPort
 import com.celuveat.member.domain.SocialLoginType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +21,9 @@ class SocialLoginService(
     private val getSocialLoginUrlPort: GetSocialLoginUrlPort,
     private val saveMemberPort: SaveMemberPort,
     private val findMemberPort: FindMemberPort,
-) : SocialLoginUseCase, GetSocialLoginUrlUseCase {
+    private val deleteMemberPort: DeleteMemberPort,
+    private val withdrawSocialMemberPort: WithdrawSocialMemberPort,
+) : SocialLoginUseCase, GetSocialLoginUrlUseCase, WithdrawSocialLoginUseCase {
     @Transactional
     override fun login(command: SocialLoginCommand): Long {
         val member = fetchSocialMemberPort.fetchMember(
@@ -35,5 +41,14 @@ class SocialLoginService(
         redirectUrl: String,
     ): String {
         return getSocialLoginUrlPort.getSocialLoginUrl(socialLoginType, redirectUrl)
+    }
+
+    override fun withdraw(command: WithdrawSocialLoginCommand) {
+        withdrawSocialMemberPort.withdraw(
+            command.authCode,
+            command.socialLoginType,
+            command.requestOrigin,
+        )
+        deleteMemberPort.deleteById(command.memberId)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/in/WithdrawSocialLoginUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/WithdrawSocialLoginUseCase.kt
@@ -1,0 +1,7 @@
+package com.celuveat.member.application.port.`in`
+
+import com.celuveat.member.application.port.`in`.command.WithdrawSocialLoginCommand
+
+interface WithdrawSocialLoginUseCase {
+    fun withdraw(command: WithdrawSocialLoginCommand)
+}

--- a/src/main/kotlin/com/celuveat/member/application/port/in/command/WithdrawSocialLoginCommand.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/command/WithdrawSocialLoginCommand.kt
@@ -1,0 +1,10 @@
+package com.celuveat.member.application.port.`in`.command
+
+import com.celuveat.member.domain.SocialLoginType
+
+data class WithdrawSocialLoginCommand(
+    val memberId: Long,
+    val authCode: String,
+    val socialLoginType: SocialLoginType,
+    val requestOrigin: String,
+)

--- a/src/main/kotlin/com/celuveat/member/application/port/out/DeleteMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/DeleteMemberPort.kt
@@ -1,0 +1,5 @@
+package com.celuveat.member.application.port.out
+
+interface DeleteMemberPort {
+    fun deleteById(memberId: Long)
+}

--- a/src/main/kotlin/com/celuveat/member/application/port/out/WithdrawSocialMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/WithdrawSocialMemberPort.kt
@@ -1,0 +1,11 @@
+package com.celuveat.member.application.port.out
+
+import com.celuveat.member.domain.SocialLoginType
+
+interface WithdrawSocialMemberPort {
+    fun withdraw(
+        authCode: String,
+        socialLoginType: SocialLoginType,
+        redirectUrl: String,
+    )
+}

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -40,7 +40,7 @@ class SocialLoginControllerTest(
             every { socialLoginUseCase.login(command) } returns 1L
             every { createAccessTokenUseCase.create(1L) } returns jwtAccessToken
 
-            mockMvc.get("/social-login/login/{socialLoginType}", socialLoginType) {
+            mockMvc.get("/social-login/{socialLoginType}", socialLoginType) {
                 param("authCode", authCode)
                 header("Origin", requestOrigin)
             }.andExpect {
@@ -54,7 +54,7 @@ class SocialLoginControllerTest(
         test("지원하지 않는 서버 타입으로 요청 하면 실패한다") {
             val unsupportedSocialLoginType = "UNSUPPORTED"
 
-            mockMvc.get("/social-login/login/{socialLoginType}", unsupportedSocialLoginType) {
+            mockMvc.get("/social-login/{socialLoginType}", unsupportedSocialLoginType) {
                 param("authCode", authCode)
             }.andExpect {
                 status { isBadRequest() }
@@ -71,7 +71,7 @@ class SocialLoginControllerTest(
         test("소셜 로그인 URL을 성공적으로 반환한다") {
             every { getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin) } returns socialLoginUrl
 
-            mockMvc.get("/social-login/login/{socialLoginType}/url", socialLoginType) {
+            mockMvc.get("/social-login/{socialLoginType}/url", socialLoginType) {
                 header("Origin", requestOrigin)
             }.andExpect {
                 status { isFound() }
@@ -82,7 +82,7 @@ class SocialLoginControllerTest(
         test("지원하지 않는 서버 타입으로 요청 하면 실패한다") {
             val unsupportedSocialLoginType = "UNSUPPORTED"
 
-            mockMvc.get("/social-login/login/{socialLoginType}/url", unsupportedSocialLoginType) {
+            mockMvc.get("/social-login/{socialLoginType}/url", unsupportedSocialLoginType) {
                 header("Origin", requestOrigin)
             }.andExpect {
                 status { isBadRequest() }

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -75,7 +75,7 @@ class SocialLoginControllerTest(
         test("소셜 로그인 URL을 성공적으로 반환한다") {
             every { getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin) } returns socialLoginUrl
 
-            mockMvc.get("/social-login/{socialLoginType}/url", socialLoginType) {
+            mockMvc.get("/social-login/url/{socialLoginType}", socialLoginType) {
                 header("Origin", requestOrigin)
             }.andExpect {
                 status { isFound() }
@@ -86,7 +86,7 @@ class SocialLoginControllerTest(
         test("지원하지 않는 서버 타입으로 요청 하면 실패한다") {
             val unsupportedSocialLoginType = "UNSUPPORTED"
 
-            mockMvc.get("/social-login/{socialLoginType}/url", unsupportedSocialLoginType) {
+            mockMvc.get("/social-login/url/{socialLoginType}", unsupportedSocialLoginType) {
                 header("Origin", requestOrigin)
             }.andExpect {
                 status { isBadRequest() }

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -5,7 +5,9 @@ import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.auth.domain.Token
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
+import com.celuveat.member.application.port.`in`.WithdrawSocialLoginUseCase
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
+import com.celuveat.member.application.port.`in`.command.WithdrawSocialLoginCommand
 import com.celuveat.member.domain.SocialLoginType
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.FunSpec
@@ -17,6 +19,7 @@ import io.mockk.unmockkAll
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 
 @WebMvcTest(SocialLoginController::class)
@@ -25,6 +28,7 @@ class SocialLoginControllerTest(
     @MockkBean val socialLoginUseCase: SocialLoginUseCase,
     @MockkBean val createAccessTokenUseCase: CreateAccessTokenUseCase,
     @MockkBean val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
+    @MockkBean val withdrawSocialLoginUseCase: WithdrawSocialLoginUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({
@@ -87,6 +91,29 @@ class SocialLoginControllerTest(
             }.andExpect {
                 status { isBadRequest() }
                 jsonPath("$.errorMessage") { value("잘못된 요청입니다.") }
+            }
+        }
+    }
+
+    context("회원 탈퇴를 요청한다") {
+        val socialLoginType = SocialLoginType.KAKAO
+        val authCode = "authCode"
+        val accessToken = "celuveatAccessToken"
+        val requestOrigin = "http://localhost:3000"
+        val memberId = 1L
+
+
+        test("소셜 로그인 회원 탈퇴 성공") {
+            val command = WithdrawSocialLoginCommand(memberId, authCode, socialLoginType, requestOrigin)
+            every { extractMemberIdUseCase.extract(accessToken) } returns memberId
+            every { withdrawSocialLoginUseCase.withdraw(command) } returns Unit
+
+            mockMvc.delete("/social-login/withdraw/{socialLoginType}", socialLoginType) {
+                param("authCode", authCode)
+                header("Origin", requestOrigin)
+                header("Authorization", "Bearer $accessToken")
+            }.andExpect {
+                status { isNoContent() }
             }
         }
     }

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -102,7 +102,6 @@ class SocialLoginControllerTest(
         val requestOrigin = "http://localhost:3000"
         val memberId = 1L
 
-
         test("소셜 로그인 회원 탈퇴 성공") {
             val command = WithdrawSocialLoginCommand(memberId, authCode, socialLoginType, requestOrigin)
             every { extractMemberIdUseCase.extract(accessToken) } returns memberId


### PR DESCRIPTION
# 관련 태스크
- closed #12 
---
회원 탈퇴 API를 개발 하였습니다!
Kakao, Naver, Google 모두 유저에 대한 `accessToken`으로 연결 해제를 요청할 수 있어 이를 추상화하여 적용하였습니다.
> 연결 해제 관련 문서 - [Kakao](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink), [Naver](https://developers.naver.com/docs/login/devguide/devguide.md#5-3-%EB%84%A4%EC%9D%B4%EB%B2%84-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%97%B0%EB%8F%99-%ED%95%B4%EC%A0%9C), [Google](https://developers.google.com/identity/protocols/oauth2/web-server#httprest_8)

accessToken을 발급 받기 위해서는 로그인 플로우처럼 `authCode`를 활용 해야해서 API요청에 추가했어요!