### PR TITLE
feat: 찜한 음식점 조회 api

### DIFF
--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/response/CelebrityResponse.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/response/CelebrityResponse.kt
@@ -94,3 +94,25 @@ data class YoutubeChannelResponse(
         }
     }
 }
+
+data class SimpleCelebrityResponse(
+    @Schema(
+        description = "연예인 이름",
+        example = "성시경",
+    )
+    val name: String,
+    @Schema(
+        description = "프로필 이미지 URL",
+        example = "https://example.com/profile.jpg",
+    )
+    val profileImageUrl: String,
+) {
+    companion object {
+        fun from(celebrity: CelebrityResult): SimpleCelebrityResponse {
+            return SimpleCelebrityResponse(
+                name = celebrity.name,
+                profileImageUrl = celebrity.profileImageUrl,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -23,4 +23,8 @@ class CelebrityPersistenceAdapter(
             .groupBy { it.celebrity.id }
         return celebrities.map { celebrityPersistenceMapper.toDomain(it, youtubeChannelsByCelebrity[it.id]!!) }
     }
+
+    override fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>> {
+        return mapOf()
+    }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -36,7 +36,7 @@ class CelebrityPersistenceAdapter(
                 visitedCelebrities.map {
                     celebrityPersistenceMapper.toDomain(
                         it.celebrity,
-                        youtubeChannelsByCelebrity[it.celebrity.id]!!
+                        youtubeChannelsByCelebrity[it.celebrity.id]!!,
                     )
                 }
             }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -3,7 +3,7 @@ package com.celuveat.celeb.adapter.out.persistence
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeChannelJpaRepository
-import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
+import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
@@ -14,7 +14,7 @@ class CelebrityPersistenceAdapter(
     private val interestedCelebrityJpaRepository: InterestedCelebrityJpaRepository,
     private val memberJpaRepository: MemberJpaRepository,
     private val celebrityPersistenceMapper: CelebrityPersistenceMapper,
-) : FindInterestedCelebritiesPort {
+) : FindCelebritiesPort {
     override fun findInterestedCelebrities(memberId: Long): List<Celebrity> {
         memberJpaRepository.getById(memberId)
         val celebrities = interestedCelebrityJpaRepository.findAllCelebritiesByMemberId(memberId)

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -2,7 +2,7 @@ package com.celuveat.celeb.adapter.out.persistence
 
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaRepository
-import com.celuveat.celeb.adapter.out.persistence.entity.VideoFeaturedRestaurantJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeChannelJpaRepository
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
@@ -13,7 +13,7 @@ import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
 class CelebrityPersistenceAdapter(
     private val youtubeChannelJpaRepository: YoutubeChannelJpaRepository,
     private val interestedCelebrityJpaRepository: InterestedCelebrityJpaRepository,
-    private val videoFeaturedRestaurantJpaRepository: VideoFeaturedRestaurantJpaRepository,
+    private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
     private val memberJpaRepository: MemberJpaRepository,
     private val celebrityPersistenceMapper: CelebrityPersistenceMapper,
 ) : FindCelebritiesPort {
@@ -27,7 +27,7 @@ class CelebrityPersistenceAdapter(
     }
 
     override fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>> {
-        val celebritiesWithRestaurant = videoFeaturedRestaurantJpaRepository.findVisitedCelebrities(restaurantIds)
+        val celebritiesWithRestaurant = restaurantInVideoJpaRepository.findVisitedCelebrities(restaurantIds)
         val celebrityIds = celebritiesWithRestaurant.map { it.celebrity.id }
         val youtubeChannelsByCelebrity = youtubeChannelJpaRepository.findAllByCelebrityIdIn(celebrityIds)
             .groupBy { it.celebrity.id }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/InterestedCelebrityJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/InterestedCelebrityJpaEntity.kt
@@ -2,7 +2,10 @@ package com.celuveat.celeb.adapter.out.persistence.entity
 
 import com.celuveat.common.adapter.out.persistence.entity.RootEntity
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
+import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -13,9 +16,11 @@ import jakarta.persistence.ManyToOne
 class InterestedCelebrityJpaEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
-    @ManyToOne @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val member: MemberJpaEntity,
-    @ManyToOne @JoinColumn(name = "celebrity_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "celebrity_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val celebrity: CelebrityJpaEntity,
 ) : RootEntity<Long>() {
     override fun id(): Long {

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/RestaurantInVideoJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/RestaurantInVideoJpaEntity.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 
 @Entity
-class VideoFeaturedRestaurantJpaEntity(
+class RestaurantInVideoJpaEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/RestaurantInVideoJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/RestaurantInVideoJpaRepository.kt
@@ -3,11 +3,11 @@ package com.celuveat.celeb.adapter.out.persistence.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface VideoFeaturedRestaurantJpaRepository : JpaRepository<VideoFeaturedRestaurantJpaEntity, Long> {
+interface RestaurantInVideoJpaRepository : JpaRepository<RestaurantInVideoJpaEntity, Long> {
     @Query(
         """
         SELECT new com.celuveat.celeb.adapter.out.persistence.entity.VisitedCelebrity(c, vfr.restaurant.id)
-        FROM VideoFeaturedRestaurantJpaEntity vfr
+        FROM RestaurantInVideoJpaEntity vfr
         JOIN vfr.video v
         JOIN v.youtubeChannel yc
         JOIN yc.celebrity c

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoFeaturedRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoFeaturedRestaurantJpaEntity.kt
@@ -1,0 +1,29 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import com.celuveat.common.adapter.out.persistence.entity.RootEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class VideoFeaturedRestaurantJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val restaurant: RestaurantJpaEntity,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "video_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val video: VideoJpaEntity,
+) : RootEntity<Long>() {
+    override fun id(): Long {
+        return this.id
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoFeaturedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoFeaturedRestaurantJpaRepository.kt
@@ -12,7 +12,7 @@ interface VideoFeaturedRestaurantJpaRepository : JpaRepository<VideoFeaturedRest
         JOIN v.youtubeChannel yc
         JOIN yc.celebrity c
         WHERE vfr.restaurant.id IN :restaurantIds
-        """
+        """,
     )
     fun findVisitedCelebrities(restaurantIds: List<Long>): List<VisitedCelebrity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoFeaturedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoFeaturedRestaurantJpaRepository.kt
@@ -1,0 +1,23 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface VideoFeaturedRestaurantJpaRepository : JpaRepository<VideoFeaturedRestaurantJpaEntity, Long> {
+    @Query(
+        """
+        SELECT new com.celuveat.celeb.adapter.out.persistence.entity.VisitedCelebrity(c, vfr.restaurant.id)
+        FROM VideoFeaturedRestaurantJpaEntity vfr
+        JOIN vfr.video v
+        JOIN v.youtubeChannel yc
+        JOIN yc.celebrity c
+        WHERE vfr.restaurant.id IN :restaurantIds
+        """
+    )
+    fun findVisitedCelebrities(restaurantIds: List<Long>): List<VisitedCelebrity>
+}
+
+data class VisitedCelebrity(
+    val celebrity: CelebrityJpaEntity,
+    val restaurantId: Long,
+)

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoJpaEntity.kt
@@ -1,0 +1,28 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import com.celuveat.common.adapter.out.persistence.entity.RootEntity
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import java.time.LocalDate
+
+@Entity
+class VideoJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val videoUrl: String,
+    val uploadDate: LocalDate,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "youtube_channel_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val youtubeChannel: YoutubeChannelJpaEntity,
+) : RootEntity<Long>() {
+    override fun id(): Long {
+        return this.id
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoJpaRepository.kt
@@ -1,0 +1,5 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VideoJpaRepository : JpaRepository<VideoJpaEntity, Long>

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -2,15 +2,15 @@ package com.celuveat.celeb.application
 
 import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
-import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
+import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import org.springframework.stereotype.Service
 
 @Service
 class CelebrityService(
-    private val findInterestedCelebritiesPort: FindInterestedCelebritiesPort,
+    private val findCelebritiesPort: FindCelebritiesPort,
 ) : GetInterestedCelebritiesUseCase {
     override fun getInterestedCelebrities(memberId: Long): List<CelebrityResult> {
-        val celebrities = findInterestedCelebritiesPort.findInterestedCelebrities(memberId)
+        val celebrities = findCelebritiesPort.findInterestedCelebrities(memberId)
         return celebrities.map { CelebrityResult.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/result/CelebrityResult.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/result/CelebrityResult.kt
@@ -1,7 +1,6 @@
 package com.celuveat.celeb.application.port.`in`.result
 
 import com.celuveat.celeb.domain.Celebrity
-import com.celuveat.celeb.domain.YoutubeChannel
 
 data class CelebrityResult(
     val id: Long,
@@ -23,26 +22,7 @@ data class CelebrityResult(
     }
 }
 
-data class YoutubeChannelResult(
-    val id: Long,
-    val channelId: String,
-    val channelUrl: String,
-    val channelName: String,
-    val contentsName: String,
-    val restaurantCount: Int,
-    val subscriberCount: Long,
-) {
-    companion object {
-        fun from(youtubeChannel: YoutubeChannel): YoutubeChannelResult {
-            return YoutubeChannelResult(
-                id = youtubeChannel.id,
-                channelId = youtubeChannel.channelId.value,
-                channelUrl = youtubeChannel.channelUrl,
-                channelName = youtubeChannel.channelName,
-                contentsName = youtubeChannel.contentsName,
-                restaurantCount = youtubeChannel.restaurantCount,
-                subscriberCount = youtubeChannel.subscriberCount,
-            )
-        }
-    }
-}
+data class SimpleCelebrityResult(
+    val name: String,
+    val profileImageUrl: String,
+)

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/result/YoutubeChannelResult.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/result/YoutubeChannelResult.kt
@@ -1,0 +1,27 @@
+package com.celuveat.celeb.application.port.`in`.result
+
+import com.celuveat.celeb.domain.YoutubeChannel
+
+data class YoutubeChannelResult(
+    val id: Long,
+    val channelId: String,
+    val channelUrl: String,
+    val channelName: String,
+    val contentsName: String,
+    val restaurantCount: Int,
+    val subscriberCount: Long,
+) {
+    companion object {
+        fun from(youtubeChannel: YoutubeChannel): YoutubeChannelResult {
+            return YoutubeChannelResult(
+                id = youtubeChannel.id,
+                channelId = youtubeChannel.channelId.value,
+                channelUrl = youtubeChannel.channelUrl,
+                channelName = youtubeChannel.channelName,
+                contentsName = youtubeChannel.contentsName,
+                restaurantCount = youtubeChannel.restaurantCount,
+                subscriberCount = youtubeChannel.subscriberCount,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
@@ -2,6 +2,6 @@ package com.celuveat.celeb.application.port.out
 
 import com.celuveat.celeb.domain.Celebrity
 
-interface FindInterestedCelebritiesPort {
+interface FindCelebritiesPort {
     fun findInterestedCelebrities(memberId: Long): List<Celebrity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
@@ -4,4 +4,5 @@ import com.celuveat.celeb.domain.Celebrity
 
 interface FindCelebritiesPort {
     fun findInterestedCelebrities(memberId: Long): List<Celebrity>
+    fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>>
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
@@ -4,5 +4,6 @@ import com.celuveat.celeb.domain.Celebrity
 
 interface FindCelebritiesPort {
     fun findInterestedCelebrities(memberId: Long): List<Celebrity>
+
     fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>>
 }

--- a/src/main/kotlin/com/celuveat/celeb/domain/Video.kt
+++ b/src/main/kotlin/com/celuveat/celeb/domain/Video.kt
@@ -1,0 +1,12 @@
+package com.celuveat.celeb.domain
+
+import com.celuveat.restaurant.domain.Restaurant
+import java.time.LocalDate
+
+data class Video(
+    val id: Long,
+    val videoUrl: String,
+    val uploadDate: LocalDate,
+    val youtubeChannel: YoutubeChannel,
+    val restaurants: List<Restaurant>,
+)

--- a/src/main/kotlin/com/celuveat/common/adapter/out/rest/response/SliceResponse.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/rest/response/SliceResponse.kt
@@ -1,0 +1,29 @@
+package com.celuveat.common.adapter.out.rest.response
+
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class SliceResponse<T>(
+    @Schema(description = "페이징 컨텐츠")
+    val contents: List<T>,
+    @Schema(description = "현재 페이지")
+    val currentPage: Int,
+    @Schema(description = "다음 페이지 존재 여부")
+    val hasNext: Boolean,
+    @Schema(description = "컨텐츠 크기")
+    val size: Int,
+) {
+    companion object {
+        fun <T, R> from(
+            sliceResult: SliceResult<R>,
+            converter: (R) -> T,
+        ): SliceResponse<T> {
+            return SliceResponse(
+                contents = sliceResult.contents.map { converter(it) },
+                currentPage = sliceResult.currentPage,
+                hasNext = sliceResult.hasNext,
+                size = sliceResult.size,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/common/application/port/in/result/SliceResult.kt
+++ b/src/main/kotlin/com/celuveat/common/application/port/in/result/SliceResult.kt
@@ -11,7 +11,7 @@ data class SliceResult<T>(
             contents = contents.map { converter(it) },
             currentPage = currentPage,
             hasNext = hasNext,
-            size = size
+            size = size,
         )
     }
 

--- a/src/main/kotlin/com/celuveat/common/application/port/in/result/SliceResult.kt
+++ b/src/main/kotlin/com/celuveat/common/application/port/in/result/SliceResult.kt
@@ -6,6 +6,14 @@ data class SliceResult<T>(
     val hasNext: Boolean,
     val size: Int,
 ) {
+    fun <R> convertContent(converter: (T) -> R): SliceResult<R> {
+        return SliceResult(
+            contents = contents.map { converter(it) },
+            currentPage = currentPage,
+            hasNext = hasNext,
+            size = size
+        )
+    }
 
     companion object {
         fun <T> of(

--- a/src/main/kotlin/com/celuveat/common/application/port/in/result/SliceResult.kt
+++ b/src/main/kotlin/com/celuveat/common/application/port/in/result/SliceResult.kt
@@ -1,0 +1,19 @@
+package com.celuveat.common.application.port.`in`.result
+
+data class SliceResult<T>(
+    val contents: List<T>,
+    val currentPage: Int,
+    val hasNext: Boolean,
+    val size: Int,
+) {
+
+    companion object {
+        fun <T> of(
+            contents: List<T>,
+            currentPage: Int,
+            hasNext: Boolean,
+        ): SliceResult<T> {
+            return SliceResult(contents, currentPage, hasNext, contents.size)
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -5,32 +5,24 @@ import com.celuveat.common.adapter.out.rest.response.SliceResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.Parameters
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestParam
 
-@Tag(name = "셀럽 API")
+@Tag(name = "음식점 API")
 interface RestaurantApi {
     @SecurityRequirement(name = "JWT")
     @Operation(summary = "관심 음식점 목록 조회")
+    @Parameters(
+        Parameter(name = "page", description = "페이지 번호", example = "0", required = true),
+        Parameter(name = "size", description = "페이지 크기", example = "10", required = true),
+    )
     @GetMapping("/interested")
     fun getInterestedRestaurants(
         @AuthId memberId: Long,
-        @Parameter(
-            `in` = ParameterIn.QUERY,
-            required = true,
-            description = "조회할 페이지, default 0",
-            example = "0",
-        )
-        @RequestParam("page") page: Int?,
-        @Parameter(
-            `in` = ParameterIn.QUERY,
-            required = true,
-            description = "조회할 크기, default 10",
-            example = "10",
-        )
-        @RequestParam("size") size: Int?,
+        @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -1,0 +1,36 @@
+package com.celuveat.restaurant.adapter.`in`.rest
+
+import com.celuveat.auth.adaptor.`in`.rest.AuthId
+import com.celuveat.common.adapter.out.rest.response.SliceResponse
+import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "셀럽 API")
+interface RestaurantApi {
+    @SecurityRequirement(name = "JWT")
+    @Operation(summary = "관심 음식점 목록 조회")
+    @GetMapping("/interested")
+    fun getInterestedRestaurants(
+        @AuthId memberId: Long,
+        @Parameter(
+            `in` = ParameterIn.QUERY,
+            required = true,
+            description = "조회할 페이지, default 0",
+            example = "0",
+        )
+        @RequestParam("page") page: Int?,
+        @Parameter(
+            `in` = ParameterIn.QUERY,
+            required = true,
+            description = "조회할 크기, default 10",
+            example = "10",
+        )
+        @RequestParam("size") size: Int?,
+    ): SliceResponse<RestaurantPreviewResponse>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -1,0 +1,37 @@
+package com.celuveat.restaurant.adapter.`in`.rest
+
+import com.celuveat.auth.adaptor.`in`.rest.AuthId
+import com.celuveat.common.adapter.out.rest.response.SliceResponse
+import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
+import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/restaurants")
+@RestController
+class RestaurantController(
+    private val getInterestedRestaurantsUseCase: GetInterestedRestaurantsUseCase,
+) : RestaurantApi {
+
+    @GetMapping("/interested")
+    override fun getInterestedRestaurants(
+        @AuthId memberId: Long,
+        @RequestParam("page") page: Int?,
+        @RequestParam("size") size: Int?,
+    ): SliceResponse<RestaurantPreviewResponse> {
+        val interestedRestaurant = getInterestedRestaurantsUseCase.getInterestedRestaurant(
+            GetInterestedRestaurantsQuery(
+                memberId = memberId,
+                page = page ?: 0,
+                size = size ?: 10,
+            )
+        )
+        return SliceResponse.from(
+            sliceResult = interestedRestaurant,
+            converter = RestaurantPreviewResponse::from,
+        )
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController
 class RestaurantController(
     private val getInterestedRestaurantsUseCase: GetInterestedRestaurantsUseCase,
 ) : RestaurantApi {
-
     @GetMapping("/interested")
     override fun getInterestedRestaurants(
         @AuthId memberId: Long,
@@ -27,7 +26,7 @@ class RestaurantController(
                 memberId = memberId,
                 page = page ?: 0,
                 size = size ?: 10,
-            )
+            ),
         )
         return SliceResponse.from(
             sliceResult = interestedRestaurant,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -5,9 +5,10 @@ import com.celuveat.common.adapter.out.rest.response.SliceResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/restaurants")
@@ -18,14 +19,13 @@ class RestaurantController(
     @GetMapping("/interested")
     override fun getInterestedRestaurants(
         @AuthId memberId: Long,
-        @RequestParam("page") page: Int?,
-        @RequestParam("size") size: Int?,
+        @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse> {
         val interestedRestaurant = getInterestedRestaurantsUseCase.getInterestedRestaurant(
             GetInterestedRestaurantsQuery(
                 memberId = memberId,
-                page = page ?: 0,
-                size = size ?: 10,
+                page = pageable.pageNumber,
+                size = pageable.pageSize,
             ),
         )
         return SliceResponse.from(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantPreviewResponse.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantPreviewResponse.kt
@@ -1,0 +1,120 @@
+package com.celuveat.restaurant.adapter.`in`.rest.response
+
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantImageResult
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class RestaurantPreviewResponse(
+    @Schema(
+        description = "식당 ID",
+        example = "1",
+    )
+    val id: Long = 0,
+    @Schema(
+        description = "식당 이름",
+        example = "맛집",
+    )
+    val name: String,
+    @Schema(
+        description = "카테고리",
+        example = "한식",
+    )
+    val category: String,
+    @Schema(
+        description = "도로명 주소",
+        example = "서울특별시 강남구 역삼동 123-456",
+    )
+    val roadAddress: String,
+    @Schema(
+        description = "전화번호",
+        example = "02-1234-5678",
+        nullable = true,
+    )
+    val phoneNumber: String?,
+    @Schema(
+        description = "네이버 지도 URL",
+        example = "https://map.naver.com/v5/entry/place/12345678",
+    )
+    val naverMapUrl: String,
+    @Schema(
+        description = "위도",
+        example = "37.123456",
+    )
+    val latitude: Double,
+    @Schema(
+        description = "경도",
+        example = "127.123456",
+    )
+    val longitude: Double,
+    @Schema(
+        description = "좋아요 여부",
+        example = "true",
+    )
+    val liked: Boolean,
+    @Schema(
+        description = "방문한 연예인 목록",
+    )
+    val visitedCelebrities: List<SimpleCelebrityResponse>,
+    @Schema(
+        description = "이미지 목록",
+    )
+    val images: List<RestaurantImageResponse>,
+) {
+    companion object {
+        fun from(restaurantPreviewResult: RestaurantPreviewResult): RestaurantPreviewResponse {
+            return RestaurantPreviewResponse(
+                id = restaurantPreviewResult.id,
+                name = restaurantPreviewResult.name,
+                category = restaurantPreviewResult.category,
+                roadAddress = restaurantPreviewResult.roadAddress,
+                phoneNumber = restaurantPreviewResult.phoneNumber,
+                naverMapUrl = restaurantPreviewResult.naverMapUrl,
+                latitude = restaurantPreviewResult.latitude,
+                longitude = restaurantPreviewResult.longitude,
+                liked = restaurantPreviewResult.liked,
+                visitedCelebrities = restaurantPreviewResult.visitedCelebrities.map {
+                    SimpleCelebrityResponse(
+                        it.name,
+                        it.profileImageUrl
+                    )
+                },
+                images = restaurantPreviewResult.images.map { RestaurantImageResponse.from(it) }
+            )
+        }
+    }
+}
+
+data class RestaurantImageResponse(
+    @Schema(
+        description = "이미지 이름",
+        example = "맛집",
+    )
+    val name: String,
+    @Schema(
+        description = "작성자",
+        example = "홍길동",
+    )
+    val author: String,
+    @Schema(
+        description = "이미지 URL",
+        example = "https://example.com/image.jpg",
+    )
+    val url: String,
+    @Schema(
+        description = "썸네일 여부",
+        example = "true",
+    )
+    val isThumbnail: Boolean,
+) {
+    companion object {
+        fun from(restaurantImage: RestaurantImageResult): RestaurantImageResponse {
+            return RestaurantImageResponse(
+                name = restaurantImage.name,
+                author = restaurantImage.author,
+                url = restaurantImage.url,
+                isThumbnail = restaurantImage.isThumbnail
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantPreviewResponse.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantPreviewResponse.kt
@@ -76,10 +76,10 @@ data class RestaurantPreviewResponse(
                 visitedCelebrities = restaurantPreviewResult.visitedCelebrities.map {
                     SimpleCelebrityResponse(
                         it.name,
-                        it.profileImageUrl
+                        it.profileImageUrl,
                     )
                 },
-                images = restaurantPreviewResult.images.map { RestaurantImageResponse.from(it) }
+                images = restaurantPreviewResult.images.map { RestaurantImageResponse.from(it) },
             )
         }
     }
@@ -113,7 +113,7 @@ data class RestaurantImageResponse(
                 name = restaurantImage.name,
                 author = restaurantImage.author,
                 url = restaurantImage.url,
-                isThumbnail = restaurantImage.isThumbnail
+                isThumbnail = restaurantImage.isThumbnail,
             )
         }
     }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -19,7 +19,7 @@ class RestaurantPersistenceAdapter(
     override fun findInterestedRestaurants(
         memberId: Long,
         page: Int,
-        size: Int
+        size: Int,
     ): SliceResult<Restaurant> {
         val pageRequest = PageRequest.of(page, size, LATEST_ID_SORTER)
         val restaurantSlice = interestedRestaurantJpaRepository.findRestaurantByMemberId(memberId, pageRequest)
@@ -29,7 +29,7 @@ class RestaurantPersistenceAdapter(
             contents = restaurantSlice.content.map {
                 restaurantPersistenceMapper.toDomain(
                     it,
-                    imagesByRestaurants[it.id]!!
+                    imagesByRestaurants[it.id]!!,
                 )
             },
             currentPage = page,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -1,0 +1,43 @@
+package com.celuveat.restaurant.adapter.out.persistence
+
+import com.celuveat.common.annotation.Adapter
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
+import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantsPort
+import com.celuveat.restaurant.domain.Restaurant
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+@Adapter
+class RestaurantPersistenceAdapter(
+    private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
+    private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
+    private val restaurantPersistenceMapper: RestaurantPersistenceMapper,
+) : FindInterestedRestaurantsPort {
+    override fun findInterestedRestaurants(
+        memberId: Long,
+        page: Int,
+        size: Int
+    ): SliceResult<Restaurant> {
+        val pageRequest = PageRequest.of(page, size, LATEST_ID_SORTER)
+        val restaurantSlice = interestedRestaurantJpaRepository.findRestaurantByMemberId(memberId, pageRequest)
+        val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurantSlice.content)
+            .groupBy { it.restaurant.id }
+        return SliceResult.of(
+            contents = restaurantSlice.content.map {
+                restaurantPersistenceMapper.toDomain(
+                    it,
+                    imagesByRestaurants[it.id]!!
+                )
+            },
+            currentPage = page,
+            hasNext = restaurantSlice.hasNext(),
+        )
+    }
+
+    companion object {
+        val LATEST_ID_SORTER = Sort.by("id").descending()
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -5,7 +5,7 @@ import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantsPort
+import com.celuveat.restaurant.application.port.out.FindRestaurantsPort
 import com.celuveat.restaurant.domain.Restaurant
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -15,7 +15,7 @@ class RestaurantPersistenceAdapter(
     private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
     private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
     private val restaurantPersistenceMapper: RestaurantPersistenceMapper,
-) : FindInterestedRestaurantsPort {
+) : FindRestaurantsPort {
     override fun findInterestedRestaurants(
         memberId: Long,
         page: Int,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
@@ -1,0 +1,24 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import com.celuveat.common.adapter.out.persistence.entity.RootEntity
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class InterestedRestaurantJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @ManyToOne @JoinColumn(name = "member_id")
+    val member: MemberJpaEntity,
+    @ManyToOne @JoinColumn(name = "restaurant_id")
+    val restaurant: RestaurantJpaEntity,
+) : RootEntity<Long>() {
+    override fun id(): Long {
+        return this.id
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
@@ -2,7 +2,10 @@ package com.celuveat.restaurant.adapter.out.persistence.entity
 
 import com.celuveat.common.adapter.out.persistence.entity.RootEntity
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
+import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -13,9 +16,11 @@ import jakarta.persistence.ManyToOne
 class InterestedRestaurantJpaEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
-    @ManyToOne @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val member: MemberJpaEntity,
-    @ManyToOne @JoinColumn(name = "restaurant_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val restaurant: RestaurantJpaEntity,
 ) : RootEntity<Long>() {
     override fun id(): Long {

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
@@ -1,0 +1,22 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface InterestedRestaurantJpaRepository : JpaRepository<InterestedRestaurantJpaEntity, Long> {
+    @EntityGraph(attributePaths = ["restaurant"])
+    fun findAllByMemberId(memberId: Long, pageable: Pageable): Slice<InterestedRestaurantJpaEntity>
+
+    @Query(
+        """
+        SELECT ir.restaurant
+        FROM InterestedRestaurantJpaEntity ir
+        WHERE ir.member.id = :memberId
+        """
+    )
+    @EntityGraph(attributePaths = ["restaurant"])
+    fun findRestaurantByMemberId(memberId: Long, pageable: Pageable): Slice<RestaurantJpaEntity>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
@@ -7,16 +7,16 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface InterestedRestaurantJpaRepository : JpaRepository<InterestedRestaurantJpaEntity, Long> {
-    @EntityGraph(attributePaths = ["restaurant"])
-    fun findAllByMemberId(memberId: Long, pageable: Pageable): Slice<InterestedRestaurantJpaEntity>
-
     @Query(
         """
         SELECT ir.restaurant
         FROM InterestedRestaurantJpaEntity ir
         WHERE ir.member.id = :memberId
-        """
+        """,
     )
     @EntityGraph(attributePaths = ["restaurant"])
-    fun findRestaurantByMemberId(memberId: Long, pageable: Pageable): Slice<RestaurantJpaEntity>
+    fun findRestaurantByMemberId(
+        memberId: Long,
+        pageable: Pageable,
+    ): Slice<RestaurantJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaEntity.kt
@@ -1,0 +1,29 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import com.celuveat.common.adapter.out.persistence.entity.RootEntity
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class RestaurantImageJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val name: String,
+    val author: String,
+    val url: String,
+    val isThumbnail: Boolean,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val restaurant: RestaurantJpaEntity
+) : RootEntity<Long>() {
+    override fun id(): Long {
+        return this.id
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaEntity.kt
@@ -21,7 +21,7 @@ class RestaurantImageJpaEntity(
     val isThumbnail: Boolean,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    val restaurant: RestaurantJpaEntity
+    val restaurant: RestaurantJpaEntity,
 ) : RootEntity<Long>() {
     override fun id(): Long {
         return this.id

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RestaurantImageJpaRepository : JpaRepository<RestaurantImageJpaEntity, Long> {
+    fun findByRestaurantIn(restaurants: List<RestaurantJpaEntity>): List<RestaurantImageJpaEntity>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaEntity.kt
@@ -1,0 +1,24 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import com.celuveat.common.adapter.out.persistence.entity.RootEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class RestaurantJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val name: String,
+    val category: String,
+    val roadAddress: String,
+    val phoneNumber: String?,
+    val naverMapUrl: String,
+    val latitude: Double,
+    val longitude: Double,
+) : RootEntity<Long>() {
+    override fun id(): Long {
+        return this.id
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RestaurantJpaRepository : JpaRepository<RestaurantJpaEntity, Long> {
+    fun findAllByIdIn(id: List<Long>): List<RestaurantJpaEntity>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantPersistenceMapper.kt
@@ -1,0 +1,33 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import com.celuveat.common.annotation.Mapper
+import com.celuveat.restaurant.domain.Restaurant
+import com.celuveat.restaurant.domain.RestaurantImage
+
+@Mapper
+class RestaurantPersistenceMapper {
+    fun toDomain(
+        restaurantJpaEntity: RestaurantJpaEntity,
+        restaurantImageJpaEntities: List<RestaurantImageJpaEntity>,
+    ): Restaurant {
+        return Restaurant(
+            id = restaurantJpaEntity.id,
+            name = restaurantJpaEntity.name,
+            category = restaurantJpaEntity.category,
+            roadAddress = restaurantJpaEntity.roadAddress,
+            phoneNumber = restaurantJpaEntity.phoneNumber,
+            naverMapUrl = restaurantJpaEntity.naverMapUrl,
+            latitude = restaurantJpaEntity.latitude,
+            longitude = restaurantJpaEntity.longitude,
+            images = restaurantImageJpaEntities.map { imageJpaEntity ->
+                RestaurantImage(
+                    id = imageJpaEntity.id,
+                    name = imageJpaEntity.name,
+                    author = imageJpaEntity.author,
+                    url = imageJpaEntity.url,
+                    isThumbnail = imageJpaEntity.isThumbnail,
+                )
+            },
+        )
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantsService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantsService.kt
@@ -1,0 +1,23 @@
+package com.celuveat.restaurant.application
+
+import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantsPort
+import com.celuveat.restaurant.domain.Restaurant
+import org.springframework.stereotype.Service
+
+@Service
+class RestaurantsService(
+    private val findInterestedRestaurantsPort: FindInterestedRestaurantsPort,
+) : GetInterestedRestaurantsUseCase {
+    override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): List<Restaurant> {
+        val interestedRestaurants = findInterestedRestaurantsPort.findInterestedRestaurants(
+            query.memberId,
+            query.page,
+            query.size,
+        )
+        
+
+        return emptyList()
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantsService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantsService.kt
@@ -20,7 +20,7 @@ class RestaurantsService(
             query.size,
         )
         val celebritiesByRestaurants = findCelebritiesPort.findVisitedCelebritiesByRestaurants(
-            interestedRestaurants.contents.map { it.id }
+            interestedRestaurants.contents.map { it.id },
         )
         return interestedRestaurants.convertContent {
             RestaurantPreviewResult.of(

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantsService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantsService.kt
@@ -1,23 +1,33 @@
 package com.celuveat.restaurant.application
 
+import com.celuveat.celeb.application.port.out.FindCelebritiesPort
+import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantsPort
-import com.celuveat.restaurant.domain.Restaurant
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
+import com.celuveat.restaurant.application.port.out.FindRestaurantsPort
 import org.springframework.stereotype.Service
 
 @Service
 class RestaurantsService(
-    private val findInterestedRestaurantsPort: FindInterestedRestaurantsPort,
+    private val findRestaurantsPort: FindRestaurantsPort,
+    private val findCelebritiesPort: FindCelebritiesPort,
 ) : GetInterestedRestaurantsUseCase {
-    override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): List<Restaurant> {
-        val interestedRestaurants = findInterestedRestaurantsPort.findInterestedRestaurants(
+    override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
+        val interestedRestaurants = findRestaurantsPort.findInterestedRestaurants(
             query.memberId,
             query.page,
             query.size,
         )
-        
-
-        return emptyList()
+        val celebritiesByRestaurants = findCelebritiesPort.findVisitedCelebritiesByRestaurants(
+            interestedRestaurants.contents.map { it.id }
+        )
+        return interestedRestaurants.convertContent {
+            RestaurantPreviewResult.of(
+                restaurant = it,
+                liked = true,
+                visitedCelebrities = celebritiesByRestaurants[it.id]!!,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/GetInterestedRestaurantsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/GetInterestedRestaurantsUseCase.kt
@@ -1,8 +1,9 @@
 package com.celuveat.restaurant.application.port.`in`
 
+import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.domain.Restaurant
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 
 interface GetInterestedRestaurantsUseCase {
-    fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): List<Restaurant>
+    fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/GetInterestedRestaurantsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/GetInterestedRestaurantsUseCase.kt
@@ -1,0 +1,8 @@
+package com.celuveat.restaurant.application.port.`in`
+
+import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.domain.Restaurant
+
+interface GetInterestedRestaurantsUseCase {
+    fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): List<Restaurant>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/GetInterestedRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/GetInterestedRestaurantsQuery.kt
@@ -4,6 +4,6 @@ const val DEFAULT_INTERESTED_RESTAURANTS_SIZE = 10
 
 data class GetInterestedRestaurantsQuery(
     val memberId: Long,
-    val page: Int,
+    val page: Int = 0,
     val size: Int = DEFAULT_INTERESTED_RESTAURANTS_SIZE,
 )

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/GetInterestedRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/GetInterestedRestaurantsQuery.kt
@@ -1,0 +1,9 @@
+package com.celuveat.restaurant.application.port.`in`.query
+
+const val DEFAULT_INTERESTED_RESTAURANTS_SIZE = 10
+
+data class GetInterestedRestaurantsQuery(
+    val memberId: Long,
+    val page: Int,
+    val size: Int = DEFAULT_INTERESTED_RESTAURANTS_SIZE,
+)

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
@@ -22,7 +22,7 @@ data class RestaurantPreviewResult(
         fun of(
             restaurant: Restaurant,
             liked: Boolean,
-            visitedCelebrities: List<Celebrity>
+            visitedCelebrities: List<Celebrity>,
         ): RestaurantPreviewResult {
             return RestaurantPreviewResult(
                 id = restaurant.id,
@@ -35,7 +35,7 @@ data class RestaurantPreviewResult(
                 longitude = restaurant.longitude,
                 liked = liked,
                 visitedCelebrities = visitedCelebrities.map { SimpleCelebrityResult(it.name, it.profileImageUrl) },
-                images = restaurant.images.map { RestaurantImageResult.from(it) }
+                images = restaurant.images.map { RestaurantImageResult.from(it) },
             )
         }
     }
@@ -47,14 +47,13 @@ data class RestaurantImageResult(
     val url: String,
     val isThumbnail: Boolean,
 ) {
-
     companion object {
         fun from(restaurantImage: RestaurantImage): RestaurantImageResult {
             return RestaurantImageResult(
                 name = restaurantImage.name,
                 author = restaurantImage.author,
                 url = restaurantImage.url,
-                isThumbnail = restaurantImage.isThumbnail
+                isThumbnail = restaurantImage.isThumbnail,
             )
         }
     }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
@@ -1,0 +1,61 @@
+package com.celuveat.restaurant.application.port.`in`.result
+
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
+import com.celuveat.celeb.domain.Celebrity
+import com.celuveat.restaurant.domain.Restaurant
+import com.celuveat.restaurant.domain.RestaurantImage
+
+data class RestaurantPreviewResult(
+    val id: Long = 0,
+    val name: String,
+    val category: String,
+    val roadAddress: String,
+    val phoneNumber: String?,
+    val naverMapUrl: String,
+    val latitude: Double,
+    val longitude: Double,
+    val liked: Boolean,
+    val visitedCelebrities: List<SimpleCelebrityResult>,
+    val images: List<RestaurantImageResult>,
+) {
+    companion object {
+        fun of(
+            restaurant: Restaurant,
+            liked: Boolean,
+            visitedCelebrities: List<Celebrity>
+        ): RestaurantPreviewResult {
+            return RestaurantPreviewResult(
+                id = restaurant.id,
+                name = restaurant.name,
+                category = restaurant.category,
+                roadAddress = restaurant.roadAddress,
+                phoneNumber = restaurant.phoneNumber,
+                naverMapUrl = restaurant.naverMapUrl,
+                latitude = restaurant.latitude,
+                longitude = restaurant.longitude,
+                liked = liked,
+                visitedCelebrities = visitedCelebrities.map { SimpleCelebrityResult(it.name, it.profileImageUrl) },
+                images = restaurant.images.map { RestaurantImageResult.from(it) }
+            )
+        }
+    }
+}
+
+data class RestaurantImageResult(
+    val name: String,
+    val author: String,
+    val url: String,
+    val isThumbnail: Boolean,
+) {
+
+    companion object {
+        fun from(restaurantImage: RestaurantImage): RestaurantImageResult {
+            return RestaurantImageResult(
+                name = restaurantImage.name,
+                author = restaurantImage.author,
+                url = restaurantImage.url,
+                isThumbnail = restaurantImage.isThumbnail
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantsPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantsPort.kt
@@ -1,8 +1,8 @@
 package com.celuveat.restaurant.application.port.out
 
-import com.celuveat.common.application.port.`in`.result.ScrollSliceResult
+import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.domain.Restaurant
 
 interface FindInterestedRestaurantsPort {
-    fun findInterestedRestaurants(memberId: Long, page: Int, size: Int): ScrollSliceResult<Restaurant>
+    fun findInterestedRestaurants(memberId: Long, page: Int, size: Int): SliceResult<Restaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantsPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantsPort.kt
@@ -1,0 +1,8 @@
+package com.celuveat.restaurant.application.port.out
+
+import com.celuveat.common.application.port.`in`.result.ScrollSliceResult
+import com.celuveat.restaurant.domain.Restaurant
+
+interface FindInterestedRestaurantsPort {
+    fun findInterestedRestaurants(memberId: Long, page: Int, size: Int): ScrollSliceResult<Restaurant>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantsPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantsPort.kt
@@ -3,6 +3,6 @@ package com.celuveat.restaurant.application.port.out
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.domain.Restaurant
 
-interface FindInterestedRestaurantsPort {
+interface FindRestaurantsPort {
     fun findInterestedRestaurants(memberId: Long, page: Int, size: Int): SliceResult<Restaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantsPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantsPort.kt
@@ -4,5 +4,9 @@ import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.domain.Restaurant
 
 interface FindRestaurantsPort {
-    fun findInterestedRestaurants(memberId: Long, page: Int, size: Int): SliceResult<Restaurant>
+    fun findInterestedRestaurants(
+        memberId: Long,
+        page: Int,
+        size: Int,
+    ): SliceResult<Restaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
@@ -1,0 +1,14 @@
+package com.celuveat.restaurant.domain
+
+data class Restaurant(
+    val id: Long = 0,
+    val name: String,
+    val category: String,
+    val roadAddress: String,
+    val phoneNumber: String?,
+    val naverMapUrl: String,
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val images: List<RestaurantImage>,
+) {
+}

--- a/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
@@ -10,5 +10,4 @@ data class Restaurant(
     val latitude: Double = 0.0,
     val longitude: Double = 0.0,
     val images: List<RestaurantImage>,
-) {
-}
+)

--- a/src/main/kotlin/com/celuveat/restaurant/domain/RestaurantImage.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/domain/RestaurantImage.kt
@@ -1,0 +1,9 @@
+package com.celuveat.restaurant.domain
+
+data class RestaurantImage(
+    val id: Long = 0,
+    val name: String,
+    val author: String,
+    val url: String,
+    val isThumbnail: Boolean,
+)

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -5,11 +5,17 @@ import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.VideoFeaturedRestaurantJpaEntity
+import com.celuveat.celeb.adapter.out.persistence.entity.VideoFeaturedRestaurantJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.VideoJpaEntity
+import com.celuveat.celeb.adapter.out.persistence.entity.VideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeChannelJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeChannelJpaRepository
 import com.celuveat.common.adapter.out.persistence.JpaConfig
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
 import com.celuveat.support.sut
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
@@ -30,6 +36,9 @@ class CelebrityPersistenceAdapterTest(
     private val interestedCelebrityJpaRepository: InterestedCelebrityJpaRepository,
     private val celebrityJpaRepository: CelebrityJpaRepository,
     private val youtubeChannelJpaRepository: YoutubeChannelJpaRepository,
+    private val restaurantJpaRepository: RestaurantJpaRepository,
+    private val videoFeaturedRestaurantJpaRepository: VideoFeaturedRestaurantJpaRepository,
+    private val videoJpaRepository: VideoJpaRepository,
 ) : StringSpec({
     "회원이 관심 목록에 추가한 셀럽을 조회 한다." {
         // given
@@ -71,4 +80,64 @@ class CelebrityPersistenceAdapterTest(
             celebrities.forAll { it.youtubeChannels shouldNotBe null }
         }
     }
+
+    "식당을 방문한 셀럽을 조회 한다." {
+        // given
+        val savedCelebrities = celebrityJpaRepository.saveAll(sut.giveMeBuilder<CelebrityJpaEntity>().sampleList(2))
+        val celebrityA = savedCelebrities[0]
+        val celebrityB = savedCelebrities[1]
+
+        val channelA = sut.giveMeBuilder<YoutubeChannelJpaEntity>()
+            .set(YoutubeChannelJpaEntity::channelId, "@channelAId")
+            .set(YoutubeChannelJpaEntity::celebrity, celebrityA)
+            .sample()
+        val channelB = sut.giveMeBuilder<YoutubeChannelJpaEntity>()
+            .set(YoutubeChannelJpaEntity::channelId, "@channelBId")
+            .set(YoutubeChannelJpaEntity::celebrity, celebrityB)
+            .sample()
+        val youtubeChannels = youtubeChannelJpaRepository.saveAll(listOf(channelA, channelB))
+
+        val savedVideos = videoJpaRepository.saveAll(
+            listOf(
+                generateVideoWithYoutubeChannel(youtubeChannels[0]).sample(),
+                generateVideoWithYoutubeChannel(youtubeChannels[1]).sample(),
+                generateVideoWithYoutubeChannel(youtubeChannels[1]).sample(),
+            ),
+        )
+
+        val restaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(2))
+        videoFeaturedRestaurantJpaRepository.saveAll(
+            listOf(
+                sut.giveMeBuilder<VideoFeaturedRestaurantJpaEntity>()
+                    .set(VideoFeaturedRestaurantJpaEntity::video, savedVideos[0])
+                    .set(VideoFeaturedRestaurantJpaEntity::restaurant, restaurants[0])
+                    .sample(),
+                sut.giveMeBuilder<VideoFeaturedRestaurantJpaEntity>()
+                    .set(VideoFeaturedRestaurantJpaEntity::video, savedVideos[1])
+                    .set(VideoFeaturedRestaurantJpaEntity::restaurant, restaurants[0])
+                    .sample(),
+                sut.giveMeBuilder<VideoFeaturedRestaurantJpaEntity>()
+                    .set(VideoFeaturedRestaurantJpaEntity::video, savedVideos[2])
+                    .set(VideoFeaturedRestaurantJpaEntity::restaurant, restaurants[1])
+                    .sample(),
+            ),
+        )
+        // fixture
+        // [셀럽A]-[채널A]-[영상1], [셀럽B]-[채널B]-[영상2]에서 [식당1] 방문
+        // [셀럽B]-[채널B]-[영상3]은 [식당2] 방문
+
+        // when
+        val visitedCelebritiesByRestaurants =
+            celebrityPersistenceAdapter.findVisitedCelebritiesByRestaurants(restaurants.map { it.id })
+
+        // then
+        assertSoftly {
+            visitedCelebritiesByRestaurants.size shouldBe 2
+            visitedCelebritiesByRestaurants[restaurants[0].id]!!.size shouldBe 2
+            visitedCelebritiesByRestaurants[restaurants[1].id]!!.size shouldBe 1
+        }
+    }
 })
+
+private fun generateVideoWithYoutubeChannel(youtubeChannel: YoutubeChannelJpaEntity) =
+    sut.giveMeBuilder<VideoJpaEntity>().set(VideoJpaEntity::youtubeChannel, youtubeChannel)

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -5,8 +5,8 @@ import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaRepository
-import com.celuveat.celeb.adapter.out.persistence.entity.VideoFeaturedRestaurantJpaEntity
-import com.celuveat.celeb.adapter.out.persistence.entity.VideoFeaturedRestaurantJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaEntity
+import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.VideoJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.VideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeChannelJpaEntity
@@ -37,7 +37,7 @@ class CelebrityPersistenceAdapterTest(
     private val celebrityJpaRepository: CelebrityJpaRepository,
     private val youtubeChannelJpaRepository: YoutubeChannelJpaRepository,
     private val restaurantJpaRepository: RestaurantJpaRepository,
-    private val videoFeaturedRestaurantJpaRepository: VideoFeaturedRestaurantJpaRepository,
+    private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
     private val videoJpaRepository: VideoJpaRepository,
 ) : StringSpec({
     "회원이 관심 목록에 추가한 셀럽을 조회 한다." {
@@ -106,19 +106,19 @@ class CelebrityPersistenceAdapterTest(
         )
 
         val restaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(2))
-        videoFeaturedRestaurantJpaRepository.saveAll(
+        restaurantInVideoJpaRepository.saveAll(
             listOf(
-                sut.giveMeBuilder<VideoFeaturedRestaurantJpaEntity>()
-                    .set(VideoFeaturedRestaurantJpaEntity::video, savedVideos[0])
-                    .set(VideoFeaturedRestaurantJpaEntity::restaurant, restaurants[0])
+                sut.giveMeBuilder<RestaurantInVideoJpaEntity>()
+                    .set(RestaurantInVideoJpaEntity::video, savedVideos[0])
+                    .set(RestaurantInVideoJpaEntity::restaurant, restaurants[0])
                     .sample(),
-                sut.giveMeBuilder<VideoFeaturedRestaurantJpaEntity>()
-                    .set(VideoFeaturedRestaurantJpaEntity::video, savedVideos[1])
-                    .set(VideoFeaturedRestaurantJpaEntity::restaurant, restaurants[0])
+                sut.giveMeBuilder<RestaurantInVideoJpaEntity>()
+                    .set(RestaurantInVideoJpaEntity::video, savedVideos[1])
+                    .set(RestaurantInVideoJpaEntity::restaurant, restaurants[0])
                     .sample(),
-                sut.giveMeBuilder<VideoFeaturedRestaurantJpaEntity>()
-                    .set(VideoFeaturedRestaurantJpaEntity::video, savedVideos[2])
-                    .set(VideoFeaturedRestaurantJpaEntity::restaurant, restaurants[1])
+                sut.giveMeBuilder<RestaurantInVideoJpaEntity>()
+                    .set(RestaurantInVideoJpaEntity::video, savedVideos[2])
+                    .set(RestaurantInVideoJpaEntity::restaurant, restaurants[1])
                     .sample(),
             ),
         )

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -1,0 +1,55 @@
+package com.celuveat.restaurant.adapter.`in`.rest
+
+import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
+import com.celuveat.support.sut
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(RestaurantController::class)
+class RestaurantControllerTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val mapper: ObjectMapper,
+    @MockkBean val getInterestedRestaurantsUseCase: GetInterestedRestaurantsUseCase,
+    // for AuthMemberArgumentResolver
+    @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
+) : FunSpec({
+
+    context("관심 목록의 셀럽을 조회 한다") {
+        val memberId = 1L
+        val accessToken = "celuveatAccessToken"
+        val page = 0
+        val results = SliceResult.of(
+            contents = sut.giveMeBuilder<RestaurantPreviewResult>()
+                .sampleList(3),
+            currentPage = page,
+            hasNext = false,
+        )
+        test("조회 성공") {
+            val query = GetInterestedRestaurantsQuery(memberId, page, size = 3)
+            every { extractMemberIdUseCase.extract(accessToken) } returns memberId
+            every { getInterestedRestaurantsUseCase.getInterestedRestaurant(query) } returns results
+
+            mockMvc.get("/restaurants/interested") {
+                header("Authorization", "Bearer $accessToken")
+                param("page", page.toString())
+                param("size", "3")
+            }.andExpect {
+                status { isOk() }
+                content { json(mapper.writeValueAsString(results)) }
+            }.andDo {
+                print()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -89,7 +89,7 @@ class RestaurantPersistenceAdapterTest(
             interestedRestaurantResults.hasNext shouldBe false
             interestedRestaurantResults.contents.map { it.id } shouldContainInOrder listOf(
                 restaurantB.id,
-                restaurantA.id
+                restaurantA.id,
             )
         }
     }

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -1,0 +1,96 @@
+package com.celuveat.restaurant.adapter.out.persistence
+
+import com.celuveat.common.adapter.out.persistence.JpaConfig
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
+import com.celuveat.support.sut
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import com.navercorp.fixturemonkey.kotlin.set
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@Import(RestaurantPersistenceAdapter::class, RestaurantPersistenceMapper::class, JpaConfig::class)
+@DataJpaTest
+class RestaurantPersistenceAdapterTest(
+    private val restaurantPersistenceAdapter: RestaurantPersistenceAdapter,
+    private val restaurantJpaRepository: RestaurantJpaRepository,
+    private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
+    private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
+    private val memberJpaRepository: MemberJpaRepository,
+) : FunSpec({
+
+    context("회원이 관심 목록에 추가한 음식점을 조회 한다.") {
+        // given
+        val savedRestaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(2))
+        val restaurantA = savedRestaurants[0]
+        val restaurantB = savedRestaurants[1]
+
+        val imagesA = sut.giveMeBuilder<RestaurantImageJpaEntity>()
+            .set(RestaurantImageJpaEntity::id, 0)
+            .set(RestaurantImageJpaEntity::restaurant, restaurantA)
+            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+            .sampleList(3)
+        val imagesB = sut.giveMeBuilder<RestaurantImageJpaEntity>()
+            .set(RestaurantImageJpaEntity::id, 0)
+            .set(RestaurantImageJpaEntity::restaurant, restaurantB)
+            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+            .sampleList(2)
+        restaurantImageJpaRepository.saveAll(imagesA + imagesB)
+
+        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
+        interestedRestaurantJpaRepository.saveAll(
+            listOf(
+                sut.giveMeBuilder<InterestedRestaurantJpaEntity>()
+                    .set(InterestedRestaurantJpaEntity::member, savedMember)
+                    .set(InterestedRestaurantJpaEntity::restaurant, savedRestaurants[0])
+                    .sample(),
+                sut.giveMeBuilder<InterestedRestaurantJpaEntity>()
+                    .set(InterestedRestaurantJpaEntity::member, savedMember)
+                    .set(InterestedRestaurantJpaEntity::restaurant, savedRestaurants[1])
+                    .sample(),
+            ),
+        )
+
+        test("추가로 조회할 수 있는 음식점의 여부를 응답한다") {
+            // when
+            val interestedRestaurantResults = restaurantPersistenceAdapter.findInterestedRestaurants(
+                savedMember.id,
+                0,
+                1,
+            )
+
+            // then
+            interestedRestaurantResults.size shouldBe 1
+            interestedRestaurantResults.hasNext shouldBe true
+            interestedRestaurantResults.contents.map { it.id } shouldBe listOf(restaurantB.id)
+        }
+
+        test("마지막 음식점을 조회한 경우 hasNext는 false를 응답한다") {
+            // when
+            val interestedRestaurantResults = restaurantPersistenceAdapter.findInterestedRestaurants(
+                savedMember.id,
+                0,
+                2,
+            )
+
+            // then
+            interestedRestaurantResults.size shouldBe 2
+            interestedRestaurantResults.hasNext shouldBe false
+            interestedRestaurantResults.contents.map { it.id } shouldContainInOrder listOf(
+                restaurantB.id,
+                restaurantA.id
+            )
+        }
+    }
+})

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantsServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantsServiceTest.kt
@@ -1,0 +1,69 @@
+package com.celuveat.restaurant.application
+
+import com.celuveat.celeb.application.port.out.FindCelebritiesPort
+import com.celuveat.celeb.domain.Celebrity
+import com.celuveat.celeb.domain.YoutubeChannel
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.out.FindRestaurantsPort
+import com.celuveat.restaurant.domain.Restaurant
+import com.celuveat.support.channelIdSpec
+import com.celuveat.support.sut
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.setExp
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class RestaurantsServiceTest : BehaviorSpec({
+
+    val findRestaurantsPort: FindRestaurantsPort = mockk()
+    val findCelebritiesPort: FindCelebritiesPort = mockk()
+
+    val restaurantsService = RestaurantsService(
+        findRestaurantsPort,
+        findCelebritiesPort,
+    )
+
+    Given("관심 식당을 조회할 때") {
+        val memberId = 1L
+        val page = 0
+        val size = 2
+        val interestedRestaurantResult = SliceResult.of(
+            contents = sut.giveMeBuilder<Restaurant>().sampleList(3),
+            currentPage = 0,
+            hasNext = false
+        )
+        val interestedRestaurantResultIds = interestedRestaurantResult.contents.map { it.id }
+        every { findRestaurantsPort.findInterestedRestaurants(memberId, page, size) } returns interestedRestaurantResult
+        every { findCelebritiesPort.findVisitedCelebritiesByRestaurants(interestedRestaurantResultIds) } returns mapOf(
+            interestedRestaurantResultIds[0] to sut.giveMeBuilder<Celebrity>()
+                .setExp(Celebrity::youtubeChannels, generateYoutubeChannels(size = 2))
+                .sampleList(2),
+            interestedRestaurantResultIds[1] to sut.giveMeBuilder<Celebrity>()
+                .setExp(Celebrity::youtubeChannels, generateYoutubeChannels(size = 1))
+                .sampleList(2),
+            interestedRestaurantResultIds[2] to sut.giveMeBuilder<Celebrity>()
+                .setExp(Celebrity::youtubeChannels, generateYoutubeChannels(size = 1))
+                .sampleList(1),
+        )
+        When("회원이 관심 식당을 조회하면") {
+            val getInterestedRestaurantsQuery = GetInterestedRestaurantsQuery(
+                memberId = memberId,
+                page = page,
+                size = size,
+            )
+            val interestedRestaurants = restaurantsService.getInterestedRestaurant(getInterestedRestaurantsQuery)
+
+            Then("관심 식당 목록을 반환한다") {
+                interestedRestaurants.contents.size shouldBe 3
+                interestedRestaurants.contents[0].visitedCelebrities.size shouldBe 2
+                interestedRestaurants.hasNext shouldBe false
+            }
+        }
+    }
+})
+
+private fun generateYoutubeChannels(size: Int = 1): List<YoutubeChannel> =
+    sut.giveMeBuilder<YoutubeChannel>().setInner(channelIdSpec).sampleList(size)

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantsServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantsServiceTest.kt
@@ -33,7 +33,7 @@ class RestaurantsServiceTest : BehaviorSpec({
         val interestedRestaurantResult = SliceResult.of(
             contents = sut.giveMeBuilder<Restaurant>().sampleList(3),
             currentPage = 0,
-            hasNext = false
+            hasNext = false,
         )
         val interestedRestaurantResultIds = interestedRestaurantResult.contents.map { it.id }
         every { findRestaurantsPort.findInterestedRestaurants(memberId, page, size) } returns interestedRestaurantResult

--- a/src/test/kotlin/com/celuveat/support/FixtureMonkeyInnerSpecs.kt
+++ b/src/test/kotlin/com/celuveat/support/FixtureMonkeyInnerSpecs.kt
@@ -1,0 +1,8 @@
+package com.celuveat.support
+
+import com.celuveat.celeb.domain.ChannelId
+import com.navercorp.fixturemonkey.customizer.InnerSpec
+
+fun randomString() = (5..8).map { ('a'..'z').random() }.joinToString("")
+
+val channelIdSpec: InnerSpec = InnerSpec().property("channelId", ChannelId("@" + randomString()))


### PR DESCRIPTION
# 관련 태스크
- closed #19
---
관심에 추가한 음식점 조회 API를 구현하였습니다.

![Screenshot 2024-08-02 at 00 24 54](https://github.com/user-attachments/assets/1273d593-3f19-4e16-bcea-962b6694d079)

음식점 정보에 방문한 셀럽의 정보가 포함되어야 하는데요.
현재 객체 그래프가 `Celebrity -> YoutubeChannel -> Video -> Restaurant` 로 이루어져 있어서 restaurant -> celebrity 까지 도달하는 쿼리가 생각보다 복잡하였습니다. 쿼리 구현 커밋 https://github.com/2024-celuveat/server/pull/20/commits/7f60b32c24ece157ff21f2bcbb892b838cf7b7be

---

추가로 스크롤 요청에 대한 `SliceResult`, `SliceResponse`를 구현하였습니다.
쿼리 요청의 경우 특별 할 것 없이 `jakarta.data.domain.Pageable`을 사용하면 되는데요.
응답의 경우 `jakarta.data.domain.Slice`가 port-in까지 사용 되는 것을 끊기 위해 추가적으로 만들었습니다.

`SliceResult.kt`
```kotlin
data class SliceResult<T>(
    val contents: List<T>,
    val currentPage: Int,
    val hasNext: Boolean,
    val size: Int,
) {
    fun <R> convertContent(converter: (T) -> R): SliceResult<R> {
        return SliceResult(
            contents = contents.map { converter(it) },
            currentPage = currentPage,
            hasNext = hasNext,
            size = size,
        )
    }

    companion object {
        fun <T> of(
            contents: List<T>,
            currentPage: Int,
            hasNext: Boolean,
        ): SliceResult<T> {
            return SliceResult(contents, currentPage, hasNext, contents.size)
        }
    }
}
```
`of()`를 통해 SliceResult를 만들 수 있습니다.
`convertContent()`의 경우 `DomainJpaEntity`를 반환하는 `Slice<>`에서  `Domain`으로 변환하는 작업이 많은 것을 고려하여 만들었습니다.

변경 사항이 많은데... 감히 리뷰 요청해봅니다..(~화이팅!!~)