### PR TITLE
feat: best셀럽 및 음식점 api

### DIFF
--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/Auth.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/Auth.kt
@@ -5,4 +5,4 @@ import io.swagger.v3.oas.annotations.Hidden
 @Hidden
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class AuthId
+annotation class Auth

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContext.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContext.kt
@@ -5,7 +5,7 @@ import com.celuveat.auth.exception.UnAuthorizationException
 data class AuthContext(
     private val memberId: Long?,
 ) {
-    fun asGuest(): Long? {
+    fun optionalMemberId(): Long? {
         return this.memberId
     }
 

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContext.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContext.kt
@@ -1,0 +1,21 @@
+package com.celuveat.auth.adaptor.`in`.rest
+
+import com.celuveat.auth.exception.UnAuthorizationException
+
+data class AuthContext(
+    private val memberId: Long?,
+) {
+    fun asGuest(): Long? {
+        return this.memberId
+    }
+
+    fun memberId(): Long {
+        return this.memberId ?: throw UnAuthorizationException
+    }
+
+    companion object {
+        fun guest(): AuthContext {
+            return AuthContext(null)
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContextArgumentResolver.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContextArgumentResolver.kt
@@ -1,8 +1,8 @@
 package com.celuveat.auth.adaptor.`in`.rest
 
 import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
-import com.celuveat.common.adapter.out.rest.getTokenAuthorizationOrNull
-import com.celuveat.common.adapter.out.rest.toHttpServletRequest
+import com.celuveat.common.adapter.`in`.rest.getTokenAuthorizationOrNull
+import com.celuveat.common.adapter.`in`.rest.toHttpServletRequest
 import org.springframework.core.MethodParameter
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContextArgumentResolver.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/AuthContextArgumentResolver.kt
@@ -16,7 +16,7 @@ class AuthContextArgumentResolver(
 ) : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.hasParameterAnnotation(Auth::class.java) &&
-                parameter.parameterType == AuthContext::class.java
+            parameter.parameterType == AuthContext::class.java
     }
 
     override fun resolveArgument(

--- a/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/config/AuthConfiguration.kt
+++ b/src/main/kotlin/com/celuveat/auth/adaptor/in/rest/config/AuthConfiguration.kt
@@ -1,15 +1,15 @@
 package com.celuveat.auth.adaptor.`in`.rest.config
 
-import com.celuveat.auth.adaptor.`in`.rest.AuthMemberArgumentResolver
+import com.celuveat.auth.adaptor.`in`.rest.AuthContextArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class AuthConfiguration(
-    private val authMemberArgumentResolver: AuthMemberArgumentResolver,
+    private val authContextArgumentResolver: AuthContextArgumentResolver,
 ) : WebMvcConfigurer {
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(authMemberArgumentResolver)
+        resolvers.add(authContextArgumentResolver)
     }
 }

--- a/src/main/kotlin/com/celuveat/auth/exception/AuthExceptions.kt
+++ b/src/main/kotlin/com/celuveat/auth/exception/AuthExceptions.kt
@@ -1,0 +1,13 @@
+package com.celuveat.auth.exception
+
+import com.celuveat.common.exception.CeluveatException
+import org.springframework.http.HttpStatus
+
+sealed class AuthExceptions(
+    status: HttpStatus,
+    errorMessage: String,
+) : CeluveatException(status, errorMessage)
+
+data object UnAuthorizationException : AuthExceptions(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다") {
+    private fun readResolve(): Any = UnAuthorizationException
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
@@ -2,6 +2,7 @@ package com.celuveat.celeb.adapter.`in`.rest
 
 import com.celuveat.auth.adaptor.`in`.rest.AuthId
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
@@ -17,7 +18,7 @@ interface CelebrityApi {
     @SecurityRequirement(name = "JWT")
     @Operation(summary = "관심 셀럽 목록 조회")
     @GetMapping("/interested")
-    fun getInterestedCelebrities(
+    fun readInterestedCelebrities(
         @AuthId memberId: Long,
     ): List<CelebrityResponse>
 
@@ -48,4 +49,9 @@ interface CelebrityApi {
         )
         @PathVariable celebrityId: Long,
     )
+
+    @SecurityRequirement(name = "JWT")
+    @Operation(summary = "인기 셀럽 조회")
+    @GetMapping("/interested")
+    fun readBestCelebrities(): List<SimpleCelebrityResponse>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
@@ -27,7 +27,7 @@ interface CelebrityApi {
     @Operation(summary = "관심 셀럽 추가")
     @PostMapping("/interested/{celebrityId}")
     fun addInterestedCelebrity(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @Parameter(
             `in` = ParameterIn.PATH,
             description = "셀럽 ID",
@@ -41,7 +41,7 @@ interface CelebrityApi {
     @Operation(summary = "관심 셀럽 삭제")
     @DeleteMapping("/interested/{celebrityId}")
     fun deleteInterestedCelebrity(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @Parameter(
             `in` = ParameterIn.PATH,
             description = "셀럽 ID",

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
@@ -51,7 +51,6 @@ interface CelebrityApi {
         @PathVariable celebrityId: Long,
     )
 
-    @SecurityRequirement(name = "JWT")
     @Operation(summary = "인기 셀럽 조회")
     @GetMapping("/interested")
     fun readBestCelebrities(): List<SimpleCelebrityResponse>

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
@@ -1,6 +1,7 @@
 package com.celuveat.celeb.adapter.`in`.rest
 
-import com.celuveat.auth.adaptor.`in`.rest.AuthId
+import com.celuveat.auth.adaptor.`in`.rest.Auth
+import com.celuveat.auth.adaptor.`in`.rest.AuthContext
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -19,7 +20,7 @@ interface CelebrityApi {
     @Operation(summary = "관심 셀럽 목록 조회")
     @GetMapping("/interested")
     fun readInterestedCelebrities(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
     ): List<CelebrityResponse>
 
     @SecurityRequirement(name = "JWT")

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
@@ -6,8 +6,8 @@ import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
-import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/celebrities")
 @RestController
 class CelebrityController(
-    private val getInterestedCelebritiesUseCase: GetInterestedCelebritiesUseCase,
+    private val readInterestedCelebritiesUseCase: ReadInterestedCelebritiesUseCase,
     private val readBestCelebritiesUseCase: ReadBestCelebritiesUseCase,
     private val addInterestedCelebrityUseCase: AddInterestedCelebrityUseCase,
     private val deleteInterestedCelebrityUseCase: DeleteInterestedCelebrityUseCase,
@@ -30,7 +30,7 @@ class CelebrityController(
         @Auth auth: AuthContext,
     ): List<CelebrityResponse> {
         val memberId = auth.memberId()
-        val celebritiesResults = getInterestedCelebritiesUseCase.getInterestedCelebrities(memberId)
+        val celebritiesResults = readInterestedCelebritiesUseCase.getInterestedCelebrities(memberId)
         return celebritiesResults.map { CelebrityResponse.from(it) }
     }
 

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
@@ -36,18 +36,20 @@ class CelebrityController(
 
     @PostMapping("/interested/{celebrityId}")
     override fun addInterestedCelebrity(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @PathVariable celebrityId: Long,
     ) {
+        val memberId = auth.memberId()
         val command = AddInterestedCelebrityCommand(memberId, celebrityId)
         addInterestedCelebrityUseCase.addInterestedCelebrity(command)
     }
 
     @DeleteMapping("/interested/{celebrityId}")
     override fun deleteInterestedCelebrity(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @PathVariable celebrityId: Long,
     ) {
+        val memberId = auth.memberId()
         val command = DeleteInterestedCelebrityCommand(memberId, celebrityId)
         deleteInterestedCelebrityUseCase.deleteInterestedCelebrity(command)
     }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
@@ -2,9 +2,11 @@ package com.celuveat.celeb.adapter.`in`.rest
 
 import com.celuveat.auth.adaptor.`in`.rest.AuthId
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -18,11 +20,12 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class CelebrityController(
     private val getInterestedCelebritiesUseCase: GetInterestedCelebritiesUseCase,
+    private val readBestCelebritiesUseCase: ReadBestCelebritiesUseCase,
     private val addInterestedCelebrityUseCase: AddInterestedCelebrityUseCase,
     private val deleteInterestedCelebrityUseCase: DeleteInterestedCelebrityUseCase,
 ) : CelebrityApi {
     @GetMapping("/interested")
-    override fun getInterestedCelebrities(
+    override fun readInterestedCelebrities(
         @AuthId memberId: Long,
     ): List<CelebrityResponse> {
         val celebritiesResults = getInterestedCelebritiesUseCase.getInterestedCelebrities(memberId)
@@ -45,5 +48,10 @@ class CelebrityController(
     ) {
         val command = DeleteInterestedCelebrityCommand(memberId, celebrityId)
         deleteInterestedCelebrityUseCase.deleteInterestedCelebrity(command)
+    }
+
+    @GetMapping("/best")
+    override fun readBestCelebrities(): List<SimpleCelebrityResponse> {
+        return readBestCelebritiesUseCase.readBestCelebrities().map { SimpleCelebrityResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
@@ -1,6 +1,7 @@
 package com.celuveat.celeb.adapter.`in`.rest
 
-import com.celuveat.auth.adaptor.`in`.rest.AuthId
+import com.celuveat.auth.adaptor.`in`.rest.Auth
+import com.celuveat.auth.adaptor.`in`.rest.AuthContext
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
@@ -26,8 +27,9 @@ class CelebrityController(
 ) : CelebrityApi {
     @GetMapping("/interested")
     override fun readInterestedCelebrities(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
     ): List<CelebrityResponse> {
+        val memberId = auth.memberId()
         val celebritiesResults = getInterestedCelebritiesUseCase.getInterestedCelebrities(memberId)
         return celebritiesResults.map { CelebrityResponse.from(it) }
     }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/response/CelebrityResponse.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/response/CelebrityResponse.kt
@@ -1,6 +1,7 @@
 package com.celuveat.celeb.adapter.`in`.rest.response
 
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.celeb.application.port.`in`.result.YoutubeContentResult
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -81,21 +82,26 @@ data class YoutubeContentResponse(
     val subscriberCount: Long,
 ) {
     companion object {
-        fun from(youtubeContent: YoutubeContentResult): YoutubeContentResponse {
+        fun from(result: YoutubeContentResult): YoutubeContentResponse {
             return YoutubeContentResponse(
-                id = youtubeContent.id,
-                channelId = youtubeContent.channelId,
-                channelUrl = youtubeContent.channelUrl,
-                channelName = youtubeContent.channelName,
-                contentsName = youtubeContent.contentsName,
-                restaurantCount = youtubeContent.restaurantCount,
-                subscriberCount = youtubeContent.subscriberCount,
+                id = result.id,
+                channelId = result.channelId,
+                channelUrl = result.channelUrl,
+                channelName = result.channelName,
+                contentsName = result.contentsName,
+                restaurantCount = result.restaurantCount,
+                subscriberCount = result.subscriberCount,
             )
         }
     }
 }
 
 data class SimpleCelebrityResponse(
+    @Schema(
+        description = "연예인 ID",
+        example = "1",
+    )
+    val id: Long,
     @Schema(
         description = "연예인 이름",
         example = "성시경",
@@ -108,10 +114,19 @@ data class SimpleCelebrityResponse(
     val profileImageUrl: String,
 ) {
     companion object {
-        fun from(celebrity: CelebrityResult): SimpleCelebrityResponse {
+        fun from(result: CelebrityResult): SimpleCelebrityResponse {
             return SimpleCelebrityResponse(
-                name = celebrity.name,
-                profileImageUrl = celebrity.profileImageUrl,
+                id = result.id,
+                name = result.name,
+                profileImageUrl = result.profileImageUrl,
+            )
+        }
+
+        fun from(result: SimpleCelebrityResult): SimpleCelebrityResponse {
+            return SimpleCelebrityResponse(
+                id = result.id,
+                name = result.name,
+                profileImageUrl = result.profileImageUrl,
             )
         }
     }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -37,7 +37,7 @@ class CelebrityPersistenceAdapter(
             .mapValues { (_, celebrityYoutubeContents) -> celebrityYoutubeContents.map { it.youtubeContent } }
 
     override fun findBestCelebrities(): List<Celebrity> {
-        return celebrityJpaRepository.findAllBySubscriberCountDesc().map {
+        return celebrityJpaRepository.findAllBySubscriberCountDescTop15().map {
             celebrityPersistenceMapper.toDomainWithoutYoutubeContent(it)
         }
     }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -1,19 +1,33 @@
 package com.celuveat.celeb.adapter.out.persistence
 
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityYoutubeContentJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeContentJpaEntity
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.common.annotation.Adapter
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
 
 @Adapter
 class CelebrityPersistenceAdapter(
+    private val celebrityJpaRepository: CelebrityJpaRepository,
     private val celebrityYoutubeContentJpaRepository: CelebrityYoutubeContentJpaRepository,
+    private val interestedCelebrityJpaRepository: InterestedCelebrityJpaRepository,
     private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
+    private val memberJpaRepository: MemberJpaRepository,
     private val celebrityPersistenceMapper: CelebrityPersistenceMapper,
 ) : FindCelebritiesPort {
+    override fun findInterestedCelebrities(memberId: Long): List<Celebrity> {
+        memberJpaRepository.getById(memberId)
+        val celebrities = interestedCelebrityJpaRepository.findAllCelebritiesByMemberId(memberId)
+        val celebrityIds = celebrities.map { it.id }
+        val youtubeContentsByCelebrity = celebritiesToContentMap(celebrityIds)
+        return celebrities.map { celebrityPersistenceMapper.toDomain(it, youtubeContentsByCelebrity[it.id]!!) }
+    }
+
     override fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>> {
         val celebritiesWithRestaurant = restaurantInVideoJpaRepository.findVisitedCelebrities(restaurantIds)
         val celebrityIds = celebritiesWithRestaurant.map { it.celebrity.id }
@@ -33,4 +47,10 @@ class CelebrityPersistenceAdapter(
         celebrityYoutubeContentJpaRepository.findByCelebrityIdIn(celebrityIds)
             .groupBy { it.celebrity.id }
             .mapValues { (_, celebrityYoutubeContents) -> celebrityYoutubeContents.map { it.youtubeContent } }
+
+    override fun findBestCelebrities(): List<Celebrity> {
+        return celebrityJpaRepository.findAllBySubscriberCountDesc().map {
+            celebrityPersistenceMapper.toDomainWithoutYoutubeContent(it)
+        }
+    }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -5,7 +5,7 @@ import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMap
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityYoutubeContentJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeContentJpaEntity
-import com.celuveat.celeb.application.port.out.FindCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.common.annotation.Adapter
 
@@ -15,7 +15,7 @@ class CelebrityPersistenceAdapter(
     private val celebrityYoutubeContentJpaRepository: CelebrityYoutubeContentJpaRepository,
     private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
     private val celebrityPersistenceMapper: CelebrityPersistenceMapper,
-) : FindCelebritiesPort {
+) : ReadCelebritiesPort {
     override fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>> {
         val celebritiesWithRestaurant = restaurantInVideoJpaRepository.findVisitedCelebrities(restaurantIds)
         val celebrityIds = celebritiesWithRestaurant.map { it.celebrity.id }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -3,31 +3,19 @@ package com.celuveat.celeb.adapter.out.persistence
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityYoutubeContentJpaRepository
-import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeContentJpaEntity
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.common.annotation.Adapter
-import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
 
 @Adapter
 class CelebrityPersistenceAdapter(
     private val celebrityJpaRepository: CelebrityJpaRepository,
     private val celebrityYoutubeContentJpaRepository: CelebrityYoutubeContentJpaRepository,
-    private val interestedCelebrityJpaRepository: InterestedCelebrityJpaRepository,
     private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
-    private val memberJpaRepository: MemberJpaRepository,
     private val celebrityPersistenceMapper: CelebrityPersistenceMapper,
 ) : FindCelebritiesPort {
-    override fun findInterestedCelebrities(memberId: Long): List<Celebrity> {
-        memberJpaRepository.getById(memberId)
-        val celebrities = interestedCelebrityJpaRepository.findAllCelebritiesByMemberId(memberId)
-        val celebrityIds = celebrities.map { it.id }
-        val youtubeContentsByCelebrity = celebritiesToContentMap(celebrityIds)
-        return celebrities.map { celebrityPersistenceMapper.toDomain(it, youtubeContentsByCelebrity[it.id]!!) }
-    }
-
     override fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>> {
         val celebritiesWithRestaurant = restaurantInVideoJpaRepository.findVisitedCelebrities(restaurantIds)
         val celebrityIds = celebritiesWithRestaurant.map { it.celebrity.id }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
@@ -63,7 +63,7 @@ class InterestedCelebrityPersistenceAdapter(
             ?: throw NotFoundInterestedCelebrityException
     }
 
-    override fun existedInterestedCelebrity(
+    override fun existsInterestedCelebrity(
         celebrityId: Long,
         memberId: Long,
     ): Boolean {

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
@@ -12,6 +12,7 @@ import com.celuveat.celeb.domain.InterestedCelebrity
 import com.celuveat.celeb.exceptions.NotFoundInterestedCelebrityException
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
+import org.springframework.transaction.annotation.Transactional
 
 @Adapter
 class InterestedCelebrityPersistenceAdapter(
@@ -38,6 +39,7 @@ class InterestedCelebrityPersistenceAdapter(
             .groupBy { it.celebrity.id }
             .mapValues { (_, celebrityYoutubeContents) -> celebrityYoutubeContents.map { it.youtubeContent } }
 
+    @Transactional
     override fun saveInterestedCelebrity(
         celebrityId: Long,
         memberId: Long,
@@ -51,6 +53,7 @@ class InterestedCelebrityPersistenceAdapter(
         interestedCelebrityJpaRepository.save(entity)
     }
 
+    @Transactional
     override fun deleteInterestedCelebrity(
         celebrityId: Long,
         memberId: Long,

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
@@ -28,7 +28,7 @@ class InterestedCelebrityPersistenceAdapter(
         return interestedCelebrities.map {
             interestedCelebrityPersistenceMapper.toDomain(
                 it,
-                youtubeContentsByCelebrity[it.id]!!
+                youtubeContentsByCelebrity[it.id]!!,
             )
         }
     }
@@ -60,7 +60,10 @@ class InterestedCelebrityPersistenceAdapter(
             ?: throw NotFoundInterestedCelebrityException
     }
 
-    override fun existedInterestedCelebrity(celebrityId: Long, memberId: Long): Boolean {
+    override fun existedInterestedCelebrity(
+        celebrityId: Long,
+        memberId: Long,
+    ): Boolean {
         return interestedCelebrityJpaRepository.existsByMemberIdAndCelebrityId(memberId, celebrityId)
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/InterestedCelebrityPersistenceAdapter.kt
@@ -6,7 +6,7 @@ import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityJpaR
 import com.celuveat.celeb.adapter.out.persistence.entity.InterestedCelebrityPersistenceMapper
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeContentJpaEntity
 import com.celuveat.celeb.application.port.out.DeleteInterestedCelebrityPort
-import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadInterestedCelebritiesPort
 import com.celuveat.celeb.application.port.out.SaveInterestedCelebrityPort
 import com.celuveat.celeb.domain.InterestedCelebrity
 import com.celuveat.celeb.exceptions.NotFoundInterestedCelebrityException
@@ -21,7 +21,7 @@ class InterestedCelebrityPersistenceAdapter(
     private val interestedCelebrityJpaRepository: InterestedCelebrityJpaRepository,
     private val memberJpaRepository: MemberJpaRepository,
     private val interestedCelebrityPersistenceMapper: InterestedCelebrityPersistenceMapper,
-) : FindInterestedCelebritiesPort, SaveInterestedCelebrityPort, DeleteInterestedCelebrityPort {
+) : ReadInterestedCelebritiesPort, SaveInterestedCelebrityPort, DeleteInterestedCelebrityPort {
     override fun findInterestedCelebrities(memberId: Long): List<InterestedCelebrity> {
         val interestedCelebrities = interestedCelebrityJpaRepository.findAllCelebritiesByMemberId(memberId)
         val celebrityIds = interestedCelebrities.map { it.celebrity.id }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaRepository.kt
@@ -3,9 +3,21 @@ package com.celuveat.celeb.adapter.out.persistence.entity
 import com.celuveat.celeb.exceptions.NotFoundCelebrityException
 import com.celuveat.common.utils.findByIdOrThrow
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface CelebrityJpaRepository : JpaRepository<CelebrityJpaEntity, Long> {
     override fun getById(id: Long): CelebrityJpaEntity {
         return this.findByIdOrThrow(id) { NotFoundCelebrityException }
     }
+
+    @Query(
+        """
+            SELECT DISTINCT (c), yc.subscriberCount
+            FROM CelebrityYoutubeContentJpaEntity cyc
+            JOIN cyc.youtubeContent yc
+            JOIN cyc.celebrity c
+            ORDER BY yc.subscriberCount DESC LIMIT 15
+        """
+    )
+    fun findAllBySubscriberCountDesc(): Set<CelebrityJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaRepository.kt
@@ -17,7 +17,7 @@ interface CelebrityJpaRepository : JpaRepository<CelebrityJpaEntity, Long> {
             JOIN cyc.youtubeContent yc
             JOIN cyc.celebrity c
             ORDER BY yc.subscriberCount DESC LIMIT 15
-        """
+        """,
     )
     fun findAllBySubscriberCountDesc(): Set<CelebrityJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaRepository.kt
@@ -19,5 +19,5 @@ interface CelebrityJpaRepository : JpaRepository<CelebrityJpaEntity, Long> {
             ORDER BY yc.subscriberCount DESC LIMIT 15
         """,
     )
-    fun findAllBySubscriberCountDesc(): Set<CelebrityJpaEntity>
+    fun findAllBySubscriberCountDescTop15(): Set<CelebrityJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityPersistenceMapper.kt
@@ -30,9 +30,7 @@ class CelebrityPersistenceMapper {
         )
     }
 
-    fun toDomainWithoutYoutubeContent(
-        celebrityJpaEntity: CelebrityJpaEntity,
-    ): Celebrity {
+    fun toDomainWithoutYoutubeContent(celebrityJpaEntity: CelebrityJpaEntity): Celebrity {
         return Celebrity(
             id = celebrityJpaEntity.id,
             name = celebrityJpaEntity.name,

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityPersistenceMapper.kt
@@ -29,4 +29,16 @@ class CelebrityPersistenceMapper {
             },
         )
     }
+
+    fun toDomainWithoutYoutubeContent(
+        celebrityJpaEntity: CelebrityJpaEntity,
+    ): Celebrity {
+        return Celebrity(
+            id = celebrityJpaEntity.id,
+            name = celebrityJpaEntity.name,
+            profileImageUrl = celebrityJpaEntity.profileImageUrl,
+            introduction = celebrityJpaEntity.introduction,
+            youtubeContents = emptyList(),
+        )
+    }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaEntity.kt
@@ -21,7 +21,7 @@ class CelebrityRestaurantJpaEntity(
     val celebrity: CelebrityJpaEntity,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    val restaurant: RestaurantJpaEntity
+    val restaurant: RestaurantJpaEntity,
 ) : RootEntity<Long>() {
     override fun id(): Long {
         return this.id

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaEntity.kt
@@ -1,0 +1,29 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import com.celuveat.common.adapter.out.persistence.entity.RootEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class CelebrityRestaurantJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "celebrity_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val celebrity: CelebrityJpaEntity,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val restaurant: RestaurantJpaEntity
+) : RootEntity<Long>() {
+    override fun id(): Long {
+        return this.id
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
@@ -12,7 +12,10 @@ interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJp
         SELECT cr.restaurant
         FROM CelebrityRestaurantJpaEntity cr
         WHERE cr.celebrity.id = :celebrityId
-        """
+        """,
     )
-    fun findRestaurantsByCelebrityId(celebrityId: Long, pageable: Pageable): Slice<RestaurantJpaEntity>
+    fun findRestaurantsByCelebrityId(
+        celebrityId: Long,
+        pageable: Pageable,
+    ): Slice<RestaurantJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
@@ -1,0 +1,18 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJpaEntity, Long> {
+    @Query(
+        """
+        SELECT cr.restaurant
+        FROM CelebrityRestaurantJpaEntity cr
+        WHERE cr.celebrity.id = :celebrityId
+        """
+    )
+    fun findRestaurantsByCelebrityId(celebrityId: Long, pageable: Pageable): Slice<RestaurantJpaEntity>
+}

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -2,15 +2,15 @@ package com.celuveat.celeb.application
 
 import com.celuveat.celeb.application.port.`in`.ReadInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
-import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadInterestedCelebritiesPort
 import org.springframework.stereotype.Service
 
 @Service
 class CelebrityQueryService(
-    private val findInterestedCelebritiesPort: FindInterestedCelebritiesPort,
+    private val readInterestedCelebritiesPort: ReadInterestedCelebritiesPort,
 ) : ReadInterestedCelebritiesUseCase {
     override fun getInterestedCelebrities(memberId: Long): List<CelebrityResult> {
-        val celebrities = findInterestedCelebritiesPort.findInterestedCelebrities(memberId)
+        val celebrities = readInterestedCelebritiesPort.findInterestedCelebrities(memberId)
         return celebrities.map { CelebrityResult.from(it.celebrity) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -1,6 +1,6 @@
 package com.celuveat.celeb.application
 
-import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
 import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
 import org.springframework.stereotype.Service
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 @Service
 class CelebrityQueryService(
     private val findInterestedCelebritiesPort: FindInterestedCelebritiesPort,
-) : GetInterestedCelebritiesUseCase {
+) : ReadInterestedCelebritiesUseCase {
     override fun getInterestedCelebrities(memberId: Long): List<CelebrityResult> {
         val celebrities = findInterestedCelebritiesPort.findInterestedCelebrities(memberId)
         return celebrities.map { CelebrityResult.from(it.celebrity) }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -1,15 +1,13 @@
 package com.celuveat.celeb.application
 
-import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
-import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
-import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
-import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
-import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
+import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.celeb.application.port.out.DeleteInterestedCelebrityPort
+import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
 import com.celuveat.celeb.application.port.out.SaveInterestedCelebrityPort
 import com.celuveat.celeb.exceptions.AlreadyInterestedCelebrityException
@@ -23,11 +21,7 @@ class CelebrityService(
     private val findInterestedCelebritiesPort: FindInterestedCelebritiesPort,
     private val saveInterestedCelebrityPort: SaveInterestedCelebrityPort,
     private val deleteInterestedCelebrityPort: DeleteInterestedCelebrityPort,
-) : GetInterestedCelebritiesUseCase, ReadBestCelebritiesUseCase, AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
-    override fun getInterestedCelebrities(memberId: Long): List<CelebrityResult> {
-        val celebrities = findCelebritiesPort.findInterestedCelebrities(memberId)
-        return celebrities.map { CelebrityResult.from(it) }
-    }
+) : ReadBestCelebritiesUseCase, AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
     @Transactional
     override fun addInterestedCelebrity(command: AddInterestedCelebrityCommand) {
         throwWhen(

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -23,7 +23,7 @@ class CelebrityService(
 ) : ReadBestCelebritiesUseCase, AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
     override fun addInterestedCelebrity(command: AddInterestedCelebrityCommand) {
         throwWhen(
-            findInterestedCelebritiesPort.existedInterestedCelebrity(command.celebrityId, command.memberId),
+            findInterestedCelebritiesPort.existsInterestedCelebrity(command.celebrityId, command.memberId),
         ) { AlreadyInterestedCelebrityException }
         saveInterestedCelebrityPort.saveInterestedCelebrity(command.celebrityId, command.memberId)
     }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -3,6 +3,7 @@ package com.celuveat.celeb.application
 import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
@@ -40,7 +41,8 @@ class CelebrityService(
         deleteInterestedCelebrityPort.deleteInterestedCelebrity(command.celebrityId, command.memberId)
     }
 
-    override fun readBestCelebrities(memberId: Long?) {
-        TODO()
+    override fun readBestCelebrities(): List<SimpleCelebrityResult> {
+        val bestCelebrities = findCelebritiesPort.findBestCelebrities()
+        return bestCelebrities.map { SimpleCelebrityResult.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -1,5 +1,9 @@
 package com.celuveat.celeb.application
 
+import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
+import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
@@ -14,10 +18,15 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CelebrityService(
+    private val findCelebritiesPort: FindCelebritiesPort,
     private val findInterestedCelebritiesPort: FindInterestedCelebritiesPort,
     private val saveInterestedCelebrityPort: SaveInterestedCelebrityPort,
     private val deleteInterestedCelebrityPort: DeleteInterestedCelebrityPort,
-) : AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
+) : GetInterestedCelebritiesUseCase, ReadBestCelebritiesUseCase, AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
+    override fun getInterestedCelebrities(memberId: Long): List<CelebrityResult> {
+        val celebrities = findCelebritiesPort.findInterestedCelebrities(memberId)
+        return celebrities.map { CelebrityResult.from(it) }
+    }
     @Transactional
     override fun addInterestedCelebrity(command: AddInterestedCelebrityCommand) {
         throwWhen(
@@ -29,5 +38,9 @@ class CelebrityService(
     @Transactional
     override fun deleteInterestedCelebrity(command: DeleteInterestedCelebrityCommand) {
         deleteInterestedCelebrityPort.deleteInterestedCelebrity(command.celebrityId, command.memberId)
+    }
+
+    override fun readBestCelebrities(memberId: Long?) {
+        TODO()
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -13,7 +13,6 @@ import com.celuveat.celeb.application.port.out.SaveInterestedCelebrityPort
 import com.celuveat.celeb.exceptions.AlreadyInterestedCelebrityException
 import com.celuveat.common.utils.throwWhen
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CelebrityService(
@@ -22,7 +21,6 @@ class CelebrityService(
     private val saveInterestedCelebrityPort: SaveInterestedCelebrityPort,
     private val deleteInterestedCelebrityPort: DeleteInterestedCelebrityPort,
 ) : ReadBestCelebritiesUseCase, AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
-    @Transactional
     override fun addInterestedCelebrity(command: AddInterestedCelebrityCommand) {
         throwWhen(
             findInterestedCelebritiesPort.existedInterestedCelebrity(command.celebrityId, command.memberId),
@@ -30,7 +28,6 @@ class CelebrityService(
         saveInterestedCelebrityPort.saveInterestedCelebrity(command.celebrityId, command.memberId)
     }
 
-    @Transactional
     override fun deleteInterestedCelebrity(command: DeleteInterestedCelebrityCommand) {
         deleteInterestedCelebrityPort.deleteInterestedCelebrity(command.celebrityId, command.memberId)
     }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -7,8 +7,8 @@ import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCo
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.celeb.application.port.out.DeleteInterestedCelebrityPort
-import com.celuveat.celeb.application.port.out.FindCelebritiesPort
-import com.celuveat.celeb.application.port.out.FindInterestedCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadInterestedCelebritiesPort
 import com.celuveat.celeb.application.port.out.SaveInterestedCelebrityPort
 import com.celuveat.celeb.exceptions.AlreadyInterestedCelebrityException
 import com.celuveat.common.utils.throwWhen
@@ -16,14 +16,14 @@ import org.springframework.stereotype.Service
 
 @Service
 class CelebrityService(
-    private val findCelebritiesPort: FindCelebritiesPort,
-    private val findInterestedCelebritiesPort: FindInterestedCelebritiesPort,
+    private val readCelebritiesPort: ReadCelebritiesPort,
+    private val readInterestedCelebritiesPort: ReadInterestedCelebritiesPort,
     private val saveInterestedCelebrityPort: SaveInterestedCelebrityPort,
     private val deleteInterestedCelebrityPort: DeleteInterestedCelebrityPort,
 ) : ReadBestCelebritiesUseCase, AddInterestedCelebrityUseCase, DeleteInterestedCelebrityUseCase {
     override fun addInterestedCelebrity(command: AddInterestedCelebrityCommand) {
         throwWhen(
-            findInterestedCelebritiesPort.existsInterestedCelebrity(command.celebrityId, command.memberId),
+            readInterestedCelebritiesPort.existsInterestedCelebrity(command.celebrityId, command.memberId),
         ) { AlreadyInterestedCelebrityException }
         saveInterestedCelebrityPort.saveInterestedCelebrity(command.celebrityId, command.memberId)
     }
@@ -33,7 +33,7 @@ class CelebrityService(
     }
 
     override fun readBestCelebrities(): List<SimpleCelebrityResult> {
-        val bestCelebrities = findCelebritiesPort.findBestCelebrities()
+        val bestCelebrities = readCelebritiesPort.findBestCelebrities()
         return bestCelebrities.map { SimpleCelebrityResult.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityService.kt
@@ -25,7 +25,7 @@ class CelebrityService(
     @Transactional
     override fun addInterestedCelebrity(command: AddInterestedCelebrityCommand) {
         throwWhen(
-            findInterestedCelebritiesPort.existedInterestedCelebrity(command.celebrityId, command.memberId)
+            findInterestedCelebritiesPort.existedInterestedCelebrity(command.celebrityId, command.memberId),
         ) { AlreadyInterestedCelebrityException }
         saveInterestedCelebrityPort.saveInterestedCelebrity(command.celebrityId, command.memberId)
     }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadBestCelebritiesUseCase.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadBestCelebritiesUseCase.kt
@@ -1,0 +1,5 @@
+package com.celuveat.celeb.application.port.`in`
+
+interface ReadBestCelebritiesUseCase {
+    fun readBestCelebrities(memberId: Long?)
+}

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadBestCelebritiesUseCase.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadBestCelebritiesUseCase.kt
@@ -1,5 +1,7 @@
 package com.celuveat.celeb.application.port.`in`
 
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
+
 interface ReadBestCelebritiesUseCase {
-    fun readBestCelebrities(memberId: Long?)
+    fun readBestCelebrities(): List<SimpleCelebrityResult>
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadInterestedCelebritiesUseCase.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadInterestedCelebritiesUseCase.kt
@@ -2,6 +2,6 @@ package com.celuveat.celeb.application.port.`in`
 
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
 
-interface GetInterestedCelebritiesUseCase {
+interface ReadInterestedCelebritiesUseCase {
     fun getInterestedCelebrities(memberId: Long): List<CelebrityResult>
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/result/CelebrityResult.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/result/CelebrityResult.kt
@@ -23,6 +23,17 @@ data class CelebrityResult(
 }
 
 data class SimpleCelebrityResult(
+    val id: Long,
     val name: String,
     val profileImageUrl: String,
-)
+) {
+    companion object {
+        fun from(celebrity: Celebrity): SimpleCelebrityResult {
+            return SimpleCelebrityResult(
+                id = celebrity.id,
+                name = celebrity.name,
+                profileImageUrl = celebrity.profileImageUrl,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/FindCelebritiesPort.kt
@@ -4,4 +4,6 @@ import com.celuveat.celeb.domain.Celebrity
 
 interface FindCelebritiesPort {
     fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>>
+
+    fun findBestCelebrities(): List<Celebrity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/FindInterestedCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/FindInterestedCelebritiesPort.kt
@@ -5,7 +5,7 @@ import com.celuveat.celeb.domain.InterestedCelebrity
 interface FindInterestedCelebritiesPort {
     fun findInterestedCelebrities(memberId: Long): List<InterestedCelebrity>
 
-    fun existedInterestedCelebrity(
+    fun existsInterestedCelebrity(
         celebrityId: Long,
         memberId: Long,
     ): Boolean

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/FindInterestedCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/FindInterestedCelebritiesPort.kt
@@ -5,5 +5,8 @@ import com.celuveat.celeb.domain.InterestedCelebrity
 interface FindInterestedCelebritiesPort {
     fun findInterestedCelebrities(memberId: Long): List<InterestedCelebrity>
 
-    fun existedInterestedCelebrity(celebrityId: Long, memberId: Long): Boolean
+    fun existedInterestedCelebrity(
+        celebrityId: Long,
+        memberId: Long,
+    ): Boolean
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadCelebritiesPort.kt
@@ -2,7 +2,7 @@ package com.celuveat.celeb.application.port.out
 
 import com.celuveat.celeb.domain.Celebrity
 
-interface FindCelebritiesPort {
+interface ReadCelebritiesPort {
     fun findVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>>
 
     fun findBestCelebrities(): List<Celebrity>

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadInterestedCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadInterestedCelebritiesPort.kt
@@ -2,7 +2,7 @@ package com.celuveat.celeb.application.port.out
 
 import com.celuveat.celeb.domain.InterestedCelebrity
 
-interface FindInterestedCelebritiesPort {
+interface ReadInterestedCelebritiesPort {
     fun findInterestedCelebrities(memberId: Long): List<InterestedCelebrity>
 
     fun existsInterestedCelebrity(

--- a/src/main/kotlin/com/celuveat/common/adapter/in/rest/CorsConfig.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/in/rest/CorsConfig.kt
@@ -1,4 +1,4 @@
-package com.celuveat.common.adapter.out.rest
+package com.celuveat.common.adapter.`in`.rest
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.AUTHORIZATION

--- a/src/main/kotlin/com/celuveat/common/adapter/in/rest/SwaggerConfig.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/in/rest/SwaggerConfig.kt
@@ -1,4 +1,4 @@
-package com.celuveat.common.adapter.out.rest
+package com.celuveat.common.adapter.`in`.rest
 
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI

--- a/src/main/kotlin/com/celuveat/common/adapter/in/rest/WebExtensions.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/in/rest/WebExtensions.kt
@@ -1,4 +1,4 @@
-package com.celuveat.common.adapter.out.rest
+package com.celuveat.common.adapter.`in`.rest
 
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.context.request.NativeWebRequest

--- a/src/main/kotlin/com/celuveat/common/adapter/in/rest/response/SliceResponse.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/in/rest/response/SliceResponse.kt
@@ -1,4 +1,4 @@
-package com.celuveat.common.adapter.out.rest.response
+package com.celuveat.common.adapter.`in`.rest.response
 
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/com/celuveat/common/adapter/out/rest/WebExtensions.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/rest/WebExtensions.kt
@@ -11,9 +11,6 @@ inline fun NativeWebRequest.toHttpServletRequest(
     return this.getNativeRequest(HttpServletRequest::class.java) ?: throw exceptionSupplier()
 }
 
-inline fun HttpServletRequest.getTokenAuthorizationOrThrow(
-    exceptionSupplier: () -> Exception = { IllegalArgumentException("Authorization header not found") },
-): String {
-    val valueWithScheme = this.getHeader("Authorization") ?: throw exceptionSupplier()
-    return valueWithScheme.removePrefix(TOKEN_AUTHORIZATION_SCHEME)
+fun HttpServletRequest.getTokenAuthorizationOrNull(): String? {
+    return this.getHeader("Authorization")?.removePrefix(TOKEN_AUTHORIZATION_SCHEME) ?: return null
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginApi.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginApi.kt
@@ -1,6 +1,7 @@
 package com.celuveat.member.adapter.`in`.rest
 
-import com.celuveat.auth.adaptor.`in`.rest.AuthId
+import com.celuveat.auth.adaptor.`in`.rest.Auth
+import com.celuveat.auth.adaptor.`in`.rest.AuthContext
 import com.celuveat.member.adapter.`in`.rest.response.LoginResponse
 import com.celuveat.member.domain.SocialLoginType
 import io.swagger.v3.oas.annotations.Operation
@@ -64,7 +65,7 @@ interface SocialLoginApi {
     @Operation(summary = "소셜 회원 탈퇴")
     @DeleteMapping("/withdraw/{socialLoginType}")
     fun withdraw(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @Parameter(
             `in` = ParameterIn.QUERY,
             required = true,

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -1,6 +1,7 @@
 package com.celuveat.member.adapter.`in`.rest
 
-import com.celuveat.auth.adaptor.`in`.rest.AuthId
+import com.celuveat.auth.adaptor.`in`.rest.Auth
+import com.celuveat.auth.adaptor.`in`.rest.AuthContext
 import com.celuveat.auth.application.port.`in`.CreateAccessTokenUseCase
 import com.celuveat.member.adapter.`in`.rest.response.LoginResponse
 import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
@@ -50,11 +51,12 @@ class SocialLoginController(
 
     @DeleteMapping("/withdraw/{socialLoginType}")
     override fun withdraw(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @RequestParam authCode: String,
         @PathVariable socialLoginType: SocialLoginType,
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
     ): ResponseEntity<Unit> {
+        val memberId = auth.memberId()
         val command = WithdrawSocialLoginCommand(memberId, authCode, socialLoginType, requestOrigin)
         withdrawSocialLoginUseCase.withdraw(command)
         return ResponseEntity.noContent().build()

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -4,7 +4,7 @@ import com.celuveat.auth.adaptor.`in`.rest.Auth
 import com.celuveat.auth.adaptor.`in`.rest.AuthContext
 import com.celuveat.auth.application.port.`in`.CreateAccessTokenUseCase
 import com.celuveat.member.adapter.`in`.rest.response.LoginResponse
-import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
+import com.celuveat.member.application.port.`in`.ReadSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
 import com.celuveat.member.application.port.`in`.WithdrawSocialLoginUseCase
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 class SocialLoginController(
     private val socialLoginUseCase: SocialLoginUseCase,
     private val createAccessTokenUseCase: CreateAccessTokenUseCase,
-    private val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
+    private val readSocialLoginUrlUseCase: ReadSocialLoginUrlUseCase,
     private val withdrawSocialLoginUseCase: WithdrawSocialLoginUseCase,
 ) : SocialLoginApi {
     @GetMapping("/{socialLoginType}")
@@ -45,7 +45,7 @@ class SocialLoginController(
         @PathVariable socialLoginType: SocialLoginType,
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
     ): String {
-        val socialLoginUrl = getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin)
+        val socialLoginUrl = readSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin)
         return socialLoginUrl
     }
 

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -2,7 +2,7 @@ package com.celuveat.member.adapter.out.oauth
 
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
-import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
+import com.celuveat.member.application.port.out.ReadSocialLoginUrlPort
 import com.celuveat.member.application.port.out.WithdrawSocialMemberPort
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialLoginType
@@ -11,7 +11,7 @@ import com.celuveat.member.exception.NotSupportedSocialLoginTypeException
 @Adapter
 class FetchSocialMemberAdapter(
     private val socialLoginClients: Set<SocialLoginClient>,
-) : FetchSocialMemberPort, GetSocialLoginUrlPort, WithdrawSocialMemberPort {
+) : FetchSocialMemberPort, ReadSocialLoginUrlPort, WithdrawSocialMemberPort {
     override fun fetchMember(
         socialLoginType: SocialLoginType,
         authCode: String,

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/MemberPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/MemberPersistenceAdapter.kt
@@ -4,7 +4,7 @@ import com.celuveat.common.annotation.Adapter
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
 import com.celuveat.member.adapter.out.persistence.entity.MemberPersistenceMapper
 import com.celuveat.member.application.port.out.DeleteMemberPort
-import com.celuveat.member.application.port.out.FindMemberPort
+import com.celuveat.member.application.port.out.ReadMemberPort
 import com.celuveat.member.application.port.out.SaveMemberPort
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialIdentifier
@@ -13,7 +13,7 @@ import com.celuveat.member.domain.SocialIdentifier
 class MemberPersistenceAdapter(
     private val memberJpaRepository: MemberJpaRepository,
     private val memberPersistenceMapper: MemberPersistenceMapper,
-) : SaveMemberPort, FindMemberPort, DeleteMemberPort {
+) : SaveMemberPort, ReadMemberPort, DeleteMemberPort {
     override fun findBySocialIdentifier(socialIdentifier: SocialIdentifier): Member? {
         return memberJpaRepository.findMemberBySocialIdAndServerType(
             socialIdentifier.socialId,

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -7,8 +7,8 @@ import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
 import com.celuveat.member.application.port.`in`.command.WithdrawSocialLoginCommand
 import com.celuveat.member.application.port.out.DeleteMemberPort
 import com.celuveat.member.application.port.out.FetchSocialMemberPort
-import com.celuveat.member.application.port.out.FindMemberPort
-import com.celuveat.member.application.port.out.GetSocialLoginUrlPort
+import com.celuveat.member.application.port.out.ReadMemberPort
+import com.celuveat.member.application.port.out.ReadSocialLoginUrlPort
 import com.celuveat.member.application.port.out.SaveMemberPort
 import com.celuveat.member.application.port.out.WithdrawSocialMemberPort
 import com.celuveat.member.domain.SocialLoginType
@@ -18,9 +18,9 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class SocialLoginService(
     private val fetchSocialMemberPort: FetchSocialMemberPort,
-    private val getSocialLoginUrlPort: GetSocialLoginUrlPort,
+    private val readSocialLoginUrlPort: ReadSocialLoginUrlPort,
     private val saveMemberPort: SaveMemberPort,
-    private val findMemberPort: FindMemberPort,
+    private val readMemberPort: ReadMemberPort,
     private val deleteMemberPort: DeleteMemberPort,
     private val withdrawSocialMemberPort: WithdrawSocialMemberPort,
 ) : SocialLoginUseCase, ReadSocialLoginUrlUseCase, WithdrawSocialLoginUseCase {
@@ -31,7 +31,7 @@ class SocialLoginService(
             command.authCode,
             command.requestOrigin,
         )
-        val signInMember = findMemberPort.findBySocialIdentifier(member.socialIdentifier)
+        val signInMember = readMemberPort.findBySocialIdentifier(member.socialIdentifier)
             ?: saveMemberPort.save(member)
         return signInMember.id
     }
@@ -40,7 +40,7 @@ class SocialLoginService(
         socialLoginType: SocialLoginType,
         requestOrigin: String,
     ): String {
-        return getSocialLoginUrlPort.getSocialLoginUrl(socialLoginType, requestOrigin)
+        return readSocialLoginUrlPort.getSocialLoginUrl(socialLoginType, requestOrigin)
     }
 
     @Transactional

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -1,6 +1,6 @@
 package com.celuveat.member.application
 
-import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
+import com.celuveat.member.application.port.`in`.ReadSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
 import com.celuveat.member.application.port.`in`.WithdrawSocialLoginUseCase
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
@@ -23,7 +23,7 @@ class SocialLoginService(
     private val findMemberPort: FindMemberPort,
     private val deleteMemberPort: DeleteMemberPort,
     private val withdrawSocialMemberPort: WithdrawSocialMemberPort,
-) : SocialLoginUseCase, GetSocialLoginUrlUseCase, WithdrawSocialLoginUseCase {
+) : SocialLoginUseCase, ReadSocialLoginUrlUseCase, WithdrawSocialLoginUseCase {
     @Transactional
     override fun login(command: SocialLoginCommand): Long {
         val member = fetchSocialMemberPort.fetchMember(

--- a/src/main/kotlin/com/celuveat/member/application/port/in/ReadSocialLoginUrlUseCase.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/ReadSocialLoginUrlUseCase.kt
@@ -2,7 +2,7 @@ package com.celuveat.member.application.port.`in`
 
 import com.celuveat.member.domain.SocialLoginType
 
-interface GetSocialLoginUrlUseCase {
+interface ReadSocialLoginUrlUseCase {
     fun getSocialLoginUrl(
         socialLoginType: SocialLoginType,
         requestOrigin: String,

--- a/src/main/kotlin/com/celuveat/member/application/port/out/ReadMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/ReadMemberPort.kt
@@ -3,6 +3,6 @@ package com.celuveat.member.application.port.out
 import com.celuveat.member.domain.Member
 import com.celuveat.member.domain.SocialIdentifier
 
-interface FindMemberPort {
+interface ReadMemberPort {
     fun findBySocialIdentifier(socialIdentifier: SocialIdentifier): Member?
 }

--- a/src/main/kotlin/com/celuveat/member/application/port/out/ReadSocialLoginUrlPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/ReadSocialLoginUrlPort.kt
@@ -2,7 +2,7 @@ package com.celuveat.member.application.port.out
 
 import com.celuveat.member.domain.SocialLoginType
 
-interface GetSocialLoginUrlPort {
+interface ReadSocialLoginUrlPort {
     fun getSocialLoginUrl(
         socialLoginType: SocialLoginType,
         requestOrigin: String,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -1,7 +1,8 @@
 package com.celuveat.restaurant.adapter.`in`.rest
 
-import com.celuveat.auth.adaptor.`in`.rest.AuthId
-import com.celuveat.common.adapter.out.rest.response.SliceResponse
+import com.celuveat.auth.adaptor.`in`.rest.Auth
+import com.celuveat.auth.adaptor.`in`.rest.AuthContext
+import com.celuveat.common.adapter.`in`.rest.response.SliceResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -26,7 +27,7 @@ interface RestaurantApi {
     )
     @GetMapping("/interested")
     fun getInterestedRestaurants(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse>
 
@@ -34,7 +35,7 @@ interface RestaurantApi {
     @Operation(summary = "관심 음식점 추가")
     @PostMapping("/interested/{restaurantId}")
     fun addInterestedRestaurant(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @Parameter(
             `in` = ParameterIn.PATH,
             description = "음식점 ID",
@@ -48,7 +49,7 @@ interface RestaurantApi {
     @Operation(summary = "관심 음식점 삭제")
     @DeleteMapping("/interested/{restaurantId}")
     fun deleteInterestedRestaurant(
-        @AuthId memberId: Long,
+        @Auth auth: AuthContext,
         @Parameter(
             `in` = ParameterIn.PATH,
             description = "음식점 ID",
@@ -57,4 +58,22 @@ interface RestaurantApi {
         )
         @PathVariable restaurantId: Long,
     )
+
+    @Operation(summary = "셀럽이 다녀간 음식점 조회")
+    @Parameters(
+        Parameter(name = "page", description = "페이지 번호", example = "0", required = true),
+        Parameter(name = "size", description = "페이지 크기", example = "10", required = true),
+    )
+    @GetMapping("/celebrity/{celebrityId}")
+    fun readCelebrityVisitedRestaurant(
+        @Auth auth: AuthContext,
+        @Parameter(
+            `in` = ParameterIn.PATH,
+            description = "셀럽 ID",
+            example = "1",
+            required = true,
+        )
+        @PathVariable celebrityId: Long,
+        @PageableDefault(size = 10, page = 0) pageable: Pageable,
+    ): SliceResponse<RestaurantPreviewResponse>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -6,12 +6,12 @@ import com.celuveat.common.adapter.`in`.rest.response.SliceResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -27,7 +27,7 @@ class RestaurantController(
     private val readInterestedRestaurantsUseCase: ReadInterestedRestaurantsUseCase,
     private val addInterestedRestaurantsUseCase: AddInterestedRestaurantsUseCase,
     private val deleteInterestedRestaurantsUseCase: DeleteInterestedRestaurantsUseCase,
-    private val readVisitedRestaurantUseCase: ReadVisitedRestaurantUseCase,
+    private val readCelebrityVisitedRestaurantUseCase: ReadCelebrityVisitedRestaurantUseCase,
 ) : RestaurantApi {
     @GetMapping("/interested")
     override fun getInterestedRestaurants(
@@ -80,13 +80,13 @@ class RestaurantController(
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse> {
         val optionalMemberId = auth.optionalMemberId()
-        val query = ReadVisitedRestaurantQuery(
+        val query = ReadCelebrityVisitedRestaurantQuery(
             memberId = optionalMemberId,
             celebrityId = celebrityId,
             page = pageable.pageNumber,
             size = pageable.pageSize,
         )
-        val visitedRestaurant = readVisitedRestaurantUseCase.readVisitedRestaurant(query)
+        val visitedRestaurant = readCelebrityVisitedRestaurantUseCase.readCelebrityVisitedRestaurant(query)
         return SliceResponse.from(
             sliceResult = visitedRestaurant,
             converter = RestaurantPreviewResponse::from,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -6,7 +6,7 @@ import com.celuveat.common.adapter.`in`.rest.response.SliceResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/restaurants")
 @RestController
 class RestaurantController(
-    private val getInterestedRestaurantsUseCase: GetInterestedRestaurantsUseCase,
+    private val readInterestedRestaurantsUseCase: ReadInterestedRestaurantsUseCase,
     private val addInterestedRestaurantsUseCase: AddInterestedRestaurantsUseCase,
     private val deleteInterestedRestaurantsUseCase: DeleteInterestedRestaurantsUseCase,
     private val readVisitedRestaurantUseCase: ReadVisitedRestaurantUseCase,
@@ -40,7 +40,7 @@ class RestaurantController(
             page = pageable.pageNumber,
             size = pageable.pageSize,
         )
-        val interestedRestaurant = getInterestedRestaurantsUseCase.getInterestedRestaurant(query)
+        val interestedRestaurant = readInterestedRestaurantsUseCase.getInterestedRestaurant(query)
         return SliceResponse.from(
             sliceResult = interestedRestaurant,
             converter = RestaurantPreviewResponse::from,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantPreviewResponse.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantPreviewResponse.kt
@@ -73,12 +73,7 @@ data class RestaurantPreviewResponse(
                 latitude = restaurantPreviewResult.latitude,
                 longitude = restaurantPreviewResult.longitude,
                 liked = restaurantPreviewResult.liked,
-                visitedCelebrities = restaurantPreviewResult.visitedCelebrities.map {
-                    SimpleCelebrityResponse(
-                        it.name,
-                        it.profileImageUrl,
-                    )
-                },
+                visitedCelebrities = restaurantPreviewResult.visitedCelebrities.map { SimpleCelebrityResponse.from(it) },
                 images = restaurantPreviewResult.images.map { RestaurantImageResponse.from(it) },
             )
         }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
@@ -1,0 +1,97 @@
+package com.celuveat.restaurant.adapter.out.persistence
+
+import com.celuveat.common.annotation.Adapter
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.common.utils.throwWhen
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantPersistenceMapper
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
+import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
+import com.celuveat.restaurant.domain.InterestedRestaurant
+import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
+import com.celuveat.restaurant.exception.NotFoundInterestedRestaurantException
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.transaction.annotation.Transactional
+
+@Adapter
+class InterestedRestaurantPersistenceAdapter(
+    private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
+    private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
+    private val interestedRestaurantPersistenceMapper: InterestedRestaurantPersistenceMapper,
+    private val restaurantJpaRepository: RestaurantJpaRepository,
+    private val memberJpaRepository: MemberJpaRepository,
+) : FindInterestedRestaurantPort, SaveInterestedRestaurantPort, DeleteInterestedRestaurantPort {
+    @Transactional(readOnly = true)
+    override fun findInterestedRestaurants(
+        memberId: Long,
+        page: Int,
+        size: Int,
+    ): SliceResult<InterestedRestaurant> {
+        val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
+        val interests = interestedRestaurantJpaRepository.findAllByMemberId(memberId, pageRequest)
+        val restaurants = interests.content.map { it.restaurant }
+        val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurants)
+            .groupBy { it.restaurant.id }
+        return SliceResult.of(
+            contents = interests.content.map {
+                interestedRestaurantPersistenceMapper.toDomain(
+                    it,
+                    imagesByRestaurants[it.restaurant.id]!!,
+                )
+            },
+            currentPage = page,
+            hasNext = interests.hasNext(),
+        )
+    }
+
+    override fun findInterestedRestaurantOrNull(
+        memberId: Long,
+        restaurantId: Long,
+    ): InterestedRestaurant? {
+        return interestedRestaurantJpaRepository.findByMemberIdAndRestaurantId(
+            memberId,
+            restaurantId,
+        )?.let { interestedRestaurantPersistenceMapper.toDomain(it) }
+    }
+
+    override fun saveInterestedRestaurant(
+        memberId: Long,
+        restaurantId: Long,
+    ) {
+        val memberJpaEntity = memberJpaRepository.getById(memberId)
+        val restaurantJpaEntity = restaurantJpaRepository.getById(restaurantId)
+        validateExistence(memberId, restaurantId)
+        interestedRestaurantJpaRepository.save(
+            InterestedRestaurantJpaEntity(
+                member = memberJpaEntity,
+                restaurant = restaurantJpaEntity,
+            ),
+        )
+    }
+
+    private fun validateExistence(
+        memberId: Long,
+        restaurantId: Long,
+    ) = throwWhen(
+        interestedRestaurantJpaRepository.existsByMemberIdAndRestaurantId(memberId, restaurantId),
+    ) { throw AlreadyInterestedRestaurantException }
+
+    override fun deleteInterestedRestaurant(
+        memberId: Long,
+        restaurantId: Long,
+    ) {
+        return interestedRestaurantJpaRepository.findByMemberIdAndRestaurantId(memberId, restaurantId)
+            ?.let { interestedRestaurantJpaRepository.delete(it) }
+            ?: throw NotFoundInterestedRestaurantException
+    }
+
+    companion object {
+        val LATEST_SORTER = Sort.by("createdAt").descending()
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
@@ -9,7 +9,7 @@ import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaura
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
 import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
 import com.celuveat.restaurant.domain.InterestedRestaurant
 import com.celuveat.restaurant.exception.NotFoundInterestedRestaurantException
@@ -24,7 +24,7 @@ class InterestedRestaurantPersistenceAdapter(
     private val interestedRestaurantPersistenceMapper: InterestedRestaurantPersistenceMapper,
     private val restaurantJpaRepository: RestaurantJpaRepository,
     private val memberJpaRepository: MemberJpaRepository,
-) : FindInterestedRestaurantPort, SaveInterestedRestaurantPort, DeleteInterestedRestaurantPort {
+) : ReadInterestedRestaurantPort, SaveInterestedRestaurantPort, DeleteInterestedRestaurantPort {
     @Transactional(readOnly = true)
     override fun findInterestedRestaurants(
         memberId: Long,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
@@ -2,7 +2,6 @@ package com.celuveat.restaurant.adapter.out.persistence
 
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.application.port.`in`.result.SliceResult
-import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
 import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
@@ -13,7 +12,6 @@ import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPo
 import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
 import com.celuveat.restaurant.domain.InterestedRestaurant
-import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
 import com.celuveat.restaurant.exception.NotFoundInterestedRestaurantException
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -50,14 +48,11 @@ class InterestedRestaurantPersistenceAdapter(
         )
     }
 
-    override fun findInterestedRestaurantOrNull(
+    override fun existsInterestedRestaurant(
         memberId: Long,
         restaurantId: Long,
-    ): InterestedRestaurant? {
-        return interestedRestaurantJpaRepository.findByMemberIdAndRestaurantId(
-            memberId,
-            restaurantId,
-        )?.let { interestedRestaurantPersistenceMapper.toDomain(it) }
+    ): Boolean {
+        return interestedRestaurantJpaRepository.existsByMemberIdAndRestaurantId(memberId, restaurantId)
     }
 
     override fun saveInterestedRestaurant(
@@ -66,7 +61,6 @@ class InterestedRestaurantPersistenceAdapter(
     ) {
         val memberJpaEntity = memberJpaRepository.getById(memberId)
         val restaurantJpaEntity = restaurantJpaRepository.getById(restaurantId)
-        validateExistence(memberId, restaurantId)
         interestedRestaurantJpaRepository.save(
             InterestedRestaurantJpaEntity(
                 member = memberJpaEntity,
@@ -74,13 +68,6 @@ class InterestedRestaurantPersistenceAdapter(
             ),
         )
     }
-
-    private fun validateExistence(
-        memberId: Long,
-        restaurantId: Long,
-    ) = throwWhen(
-        interestedRestaurantJpaRepository.existsByMemberIdAndRestaurantId(memberId, restaurantId),
-    ) { throw AlreadyInterestedRestaurantException }
 
     override fun deleteInterestedRestaurant(
         memberId: Long,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapter.kt
@@ -91,6 +91,14 @@ class InterestedRestaurantPersistenceAdapter(
             ?: throw NotFoundInterestedRestaurantException
     }
 
+    override fun findInterestedRestaurantsByIds(
+        memberId: Long,
+        restaurantIds: List<Long>,
+    ): List<InterestedRestaurant> {
+        return interestedRestaurantJpaRepository.findAllByMemberIdAndIdIn(memberId, restaurantIds)
+            .map { interestedRestaurantPersistenceMapper.toDomain(it) }
+    }
+
     companion object {
         val LATEST_SORTER = Sort.by("createdAt").descending()
     }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -19,7 +19,7 @@ class RestaurantPersistenceAdapter(
     override fun findVisitedRestaurantByCelebrity(
         celebrityId: Long,
         page: Int,
-        size: Int
+        size: Int,
     ): SliceResult<Restaurant> {
         val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
         val restaurantSlice = celebrityRestaurantJpaRepository.findRestaurantsByCelebrityId(celebrityId, pageRequest)

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -5,7 +5,7 @@ import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
-import com.celuveat.restaurant.application.port.out.FindRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -15,7 +15,7 @@ class RestaurantPersistenceAdapter(
     private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
     private val restaurantPersistenceMapper: RestaurantPersistenceMapper,
     private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
-) : FindRestaurantPort {
+) : ReadRestaurantPort {
     override fun findVisitedRestaurantByCelebrity(
         celebrityId: Long,
         page: Int,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -37,11 +37,6 @@ class RestaurantPersistenceAdapter(
         )
     }
 
-    override fun findInterestedRestaurantsByIds(restaurantIds: List<Long>): List<Restaurant> {
-        TODO("Not yet implemented")
-    }
-
-
     companion object {
         val LATEST_SORTER = Sort.by("createdAt").descending()
     }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -3,96 +3,19 @@ package com.celuveat.restaurant.adapter.out.persistence
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.application.port.`in`.result.SliceResult
-import com.celuveat.common.utils.throwWhen
-import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
-import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
-import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
-import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
-import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
-import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
-import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
-import com.celuveat.restaurant.exception.NotFoundInterestedRestaurantException
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 
 @Adapter
 class RestaurantPersistenceAdapter(
-    private val restaurantJpaRepository: RestaurantJpaRepository,
     private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
-    private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
     private val restaurantPersistenceMapper: RestaurantPersistenceMapper,
     private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
-    private val memberJpaRepository: MemberJpaRepository,
-) : FindRestaurantPort, SaveRestaurantPort, DeleteRestaurantPort {
-    override fun findInterestedRestaurants(
-        memberId: Long,
-        page: Int,
-        size: Int,
-    ): SliceResult<Restaurant> {
-        val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
-        val restaurantSlice = interestedRestaurantJpaRepository.findRestaurantByMemberId(memberId, pageRequest)
-        val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurantSlice.content)
-            .groupBy { it.restaurant.id }
-        return SliceResult.of(
-            contents = restaurantSlice.content.map {
-                restaurantPersistenceMapper.toDomain(
-                    it,
-                    imagesByRestaurants[it.id]!!,
-                )
-            },
-            currentPage = page,
-            hasNext = restaurantSlice.hasNext(),
-        )
-    }
-
-    override fun findInterestedRestaurantOrNull(
-        memberId: Long,
-        restaurantId: Long,
-    ): Restaurant? {
-        val interestedRestaurant = interestedRestaurantJpaRepository.findByMemberIdAndRestaurantId(
-            memberId,
-            restaurantId,
-        )
-        return interestedRestaurant?.restaurant?.let {
-            restaurantPersistenceMapper.toDomainWithoutImage(it)
-        }
-    }
-
-    override fun saveInterestedRestaurant(
-        memberId: Long,
-        restaurantId: Long,
-    ) {
-        val memberJpaEntity = memberJpaRepository.getById(memberId)
-        val restaurantJpaEntity = restaurantJpaRepository.getById(restaurantId)
-        validateExistence(memberId, restaurantId)
-        interestedRestaurantJpaRepository.save(
-            InterestedRestaurantJpaEntity(
-                member = memberJpaEntity,
-                restaurant = restaurantJpaEntity,
-            ),
-        )
-    }
-
-    private fun validateExistence(
-        memberId: Long,
-        restaurantId: Long,
-    ) = throwWhen(
-        interestedRestaurantJpaRepository.existsByMemberIdAndRestaurantId(memberId, restaurantId),
-    ) { throw AlreadyInterestedRestaurantException }
-
-    override fun deleteInterestedRestaurant(
-        memberId: Long,
-        restaurantId: Long,
-    ) {
-        return interestedRestaurantJpaRepository.findByMemberIdAndRestaurantId(memberId, restaurantId)
-            ?.let { interestedRestaurantJpaRepository.delete(it) }
-            ?: throw NotFoundInterestedRestaurantException
-    }
-
+) : FindRestaurantPort {
     override fun findVisitedRestaurantByCelebrity(
         celebrityId: Long,
         page: Int,
@@ -112,6 +35,10 @@ class RestaurantPersistenceAdapter(
             currentPage = page,
             hasNext = restaurantSlice.hasNext(),
         )
+    }
+
+    override fun findInterestedRestaurantsByIds(restaurantIds: List<Long>): List<Restaurant> {
+        TODO("Not yet implemented")
     }
 
 

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
@@ -11,8 +11,11 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
+@Table(uniqueConstraints = [UniqueConstraint(columnNames = ["member_id", "restaurant_id"])])
 class InterestedRestaurantJpaEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface InterestedRestaurantJpaRepository : JpaRepository<InterestedRestaurantJpaEntity, Long> {
     @EntityGraph(attributePaths = ["restaurant"])
@@ -23,6 +24,14 @@ interface InterestedRestaurantJpaRepository : JpaRepository<InterestedRestaurant
         restaurantId: Long,
     ): Boolean
 
+    @Query(
+        """
+        SELECT ir
+        FROM InterestedRestaurantJpaEntity ir
+        WHERE ir.member.id = :memberId
+        AND ir.restaurant.id IN :ids
+    """
+    )
     fun findAllByMemberIdAndIdIn(
         memberId: Long,
         ids: List<Long>,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
@@ -22,4 +22,9 @@ interface InterestedRestaurantJpaRepository : JpaRepository<InterestedRestaurant
         memberId: Long,
         restaurantId: Long,
     ): Boolean
+
+    fun findAllByMemberIdAndIdIn(
+        memberId: Long,
+        ids: List<Long>,
+    ): List<InterestedRestaurantJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaRepository.kt
@@ -4,21 +4,13 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 
 interface InterestedRestaurantJpaRepository : JpaRepository<InterestedRestaurantJpaEntity, Long> {
-    @Query(
-        """
-        SELECT ir.restaurant
-        FROM InterestedRestaurantJpaEntity ir
-        WHERE ir.member.id = :memberId
-        """,
-    )
     @EntityGraph(attributePaths = ["restaurant"])
-    fun findRestaurantByMemberId(
+    fun findAllByMemberId(
         memberId: Long,
         pageable: Pageable,
-    ): Slice<RestaurantJpaEntity>
+    ): Slice<InterestedRestaurantJpaEntity>
 
     @EntityGraph(attributePaths = ["restaurant"])
     fun findByMemberIdAndRestaurantId(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantPersistenceMapper.kt
@@ -1,0 +1,28 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import com.celuveat.common.annotation.Mapper
+import com.celuveat.member.adapter.out.persistence.entity.MemberPersistenceMapper
+import com.celuveat.restaurant.domain.InterestedRestaurant
+
+@Mapper
+class InterestedRestaurantPersistenceMapper(
+    private val restaurantPersistenceMapper: RestaurantPersistenceMapper,
+    private val memberPersistenceMapper: MemberPersistenceMapper,
+) {
+    fun toDomain(
+        interestedRestaurant: InterestedRestaurantJpaEntity,
+        restaurantImages: List<RestaurantImageJpaEntity>,
+    ): InterestedRestaurant {
+        return InterestedRestaurant(
+            member = memberPersistenceMapper.toDomain(interestedRestaurant.member),
+            restaurant = restaurantPersistenceMapper.toDomain(interestedRestaurant.restaurant, restaurantImages),
+        )
+    }
+
+    fun toDomain(interestedRestaurant: InterestedRestaurantJpaEntity): InterestedRestaurant {
+        return InterestedRestaurant(
+            member = memberPersistenceMapper.toDomain(interestedRestaurant.member),
+            restaurant = restaurantPersistenceMapper.toDomainWithoutImage(interestedRestaurant.restaurant),
+        )
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -33,7 +33,11 @@ class RestaurantQueryService(
         }
     }
 
-    override fun readVisitedRestaurant(command: ReadVisitedRestaurantQuery) {
-
+    override fun readVisitedRestaurant(query: ReadVisitedRestaurantQuery) {
+        val visitedRestaurants = findRestaurantPort.findVisitedRestaurantByCelebrity(
+            query.celebrityId,
+            query.page,
+            query.size,
+        )
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -2,26 +2,19 @@ package com.celuveat.restaurant.application
 
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
-import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
-import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
+import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
-import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
-import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
-class RestaurantsService(
+class RestaurantQueryService(
     private val findRestaurantPort: FindRestaurantPort,
     private val findCelebritiesPort: FindCelebritiesPort,
-    private val saveRestaurantPort: SaveRestaurantPort,
-    private val deleteRestaurantPort: DeleteRestaurantPort,
-) : GetInterestedRestaurantsUseCase, AddInterestedRestaurantsUseCase, DeleteInterestedRestaurantsUseCase {
+) : GetInterestedRestaurantsUseCase, ReadVisitedRestaurantUseCase {
     override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = findRestaurantPort.findInterestedRestaurants(
             query.memberId,
@@ -40,19 +33,7 @@ class RestaurantsService(
         }
     }
 
-    @Transactional
-    override fun addInterestedRestaurant(command: AddInterestedRestaurantCommand) {
-        saveRestaurantPort.saveInterestedRestaurant(
-            memberId = command.memberId,
-            restaurantId = command.restaurantId,
-        )
-    }
+    override fun readVisitedRestaurant(command: ReadVisitedRestaurantQuery) {
 
-    @Transactional
-    override fun deleteInterestedRestaurant(command: DeleteInterestedRestaurantCommand) {
-        deleteRestaurantPort.deleteInterestedRestaurant(
-            memberId = command.memberId,
-            restaurantId = command.restaurantId,
-        )
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -7,6 +7,7 @@ import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCas
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
+import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
 import org.springframework.stereotype.Service
 
@@ -14,21 +15,22 @@ import org.springframework.stereotype.Service
 class RestaurantQueryService(
     private val findRestaurantPort: FindRestaurantPort,
     private val findCelebritiesPort: FindCelebritiesPort,
+    private val findInterestedRestaurantPort: FindInterestedRestaurantPort,
 ) : GetInterestedRestaurantsUseCase, ReadVisitedRestaurantUseCase {
     override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
-        val interestedRestaurants = findRestaurantPort.findInterestedRestaurants(
+        val interestedRestaurants = findInterestedRestaurantPort.findInterestedRestaurants(
             query.memberId,
             query.page,
             query.size,
         )
         val celebritiesByRestaurants = findCelebritiesPort.findVisitedCelebritiesByRestaurants(
-            interestedRestaurants.contents.map { it.id },
+            interestedRestaurants.contents.map { it.restaurant.id },
         )
         return interestedRestaurants.convertContent {
             RestaurantPreviewResult.of(
-                restaurant = it,
+                restaurant = it.restaurant,
                 liked = true,
-                visitedCelebrities = celebritiesByRestaurants[it.id]!!,
+                visitedCelebrities = celebritiesByRestaurants[it.restaurant.id]!!,
             )
         }
     }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -2,7 +2,7 @@ package com.celuveat.restaurant.application
 
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
-import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
@@ -16,7 +16,7 @@ class RestaurantQueryService(
     private val findRestaurantPort: FindRestaurantPort,
     private val findCelebritiesPort: FindCelebritiesPort,
     private val findInterestedRestaurantPort: FindInterestedRestaurantPort,
-) : GetInterestedRestaurantsUseCase, ReadVisitedRestaurantUseCase {
+) : ReadInterestedRestaurantsUseCase, ReadVisitedRestaurantUseCase {
     override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = findInterestedRestaurantPort.findInterestedRestaurants(
             query.memberId,

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceCelebrity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceCelebrity.kt
@@ -1,29 +1,29 @@
 package com.celuveat.restaurant.application
 
-import com.celuveat.celeb.application.port.out.FindCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
-import com.celuveat.restaurant.application.port.out.FindRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import org.springframework.stereotype.Service
 
 @Service
 class RestaurantQueryServiceCelebrity(
-    private val findRestaurantPort: FindRestaurantPort,
-    private val findCelebritiesPort: FindCelebritiesPort,
-    private val findInterestedRestaurantPort: FindInterestedRestaurantPort,
+    private val readRestaurantPort: ReadRestaurantPort,
+    private val readCelebritiesPort: ReadCelebritiesPort,
+    private val readInterestedRestaurantPort: ReadInterestedRestaurantPort,
 ) : ReadInterestedRestaurantsUseCase, ReadCelebrityVisitedRestaurantUseCase {
     override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
-        val interestedRestaurants = findInterestedRestaurantPort.findInterestedRestaurants(
+        val interestedRestaurants = readInterestedRestaurantPort.findInterestedRestaurants(
             query.memberId,
             query.page,
             query.size,
         )
-        val celebritiesByRestaurants = findCelebritiesPort.findVisitedCelebritiesByRestaurants(
+        val celebritiesByRestaurants = readCelebritiesPort.findVisitedCelebritiesByRestaurants(
             interestedRestaurants.contents.map { it.restaurant.id },
         )
         return interestedRestaurants.convertContent {
@@ -36,14 +36,14 @@ class RestaurantQueryServiceCelebrity(
     }
 
     override fun readCelebrityVisitedRestaurant(query: ReadCelebrityVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult> {
-        val visitedRestaurants = findRestaurantPort.findVisitedRestaurantByCelebrity(
+        val visitedRestaurants = readRestaurantPort.findVisitedRestaurantByCelebrity(
             query.celebrityId,
             query.page,
             query.size,
         )
         val visitedRestaurantIds = visitedRestaurants.contents.map { it.id }
         val interestedRestaurants = query.memberId?.let {
-            findInterestedRestaurantPort.findInterestedRestaurantsByIds(it, visitedRestaurantIds)
+            readInterestedRestaurantPort.findInterestedRestaurantsByIds(it, visitedRestaurantIds)
         } ?: emptyList()
         return visitedRestaurants.convertContent {
             RestaurantPreviewResult.of(

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceCelebrity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceCelebrity.kt
@@ -2,21 +2,21 @@ package com.celuveat.restaurant.application
 
 import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
 import org.springframework.stereotype.Service
 
 @Service
-class RestaurantQueryService(
+class RestaurantQueryServiceCelebrity(
     private val findRestaurantPort: FindRestaurantPort,
     private val findCelebritiesPort: FindCelebritiesPort,
     private val findInterestedRestaurantPort: FindInterestedRestaurantPort,
-) : ReadInterestedRestaurantsUseCase, ReadVisitedRestaurantUseCase {
+) : ReadInterestedRestaurantsUseCase, ReadCelebrityVisitedRestaurantUseCase {
     override fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = findInterestedRestaurantPort.findInterestedRestaurants(
             query.memberId,
@@ -35,7 +35,7 @@ class RestaurantQueryService(
         }
     }
 
-    override fun readVisitedRestaurant(query: ReadVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult> {
+    override fun readCelebrityVisitedRestaurant(query: ReadCelebrityVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult> {
         val visitedRestaurants = findRestaurantPort.findVisitedRestaurantByCelebrity(
             query.celebrityId,
             query.page,

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
@@ -4,19 +4,19 @@ import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUse
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
-import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
-import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
+import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class RestaurantService(
-    private val saveRestaurantPort: SaveRestaurantPort,
-    private val deleteRestaurantPort: DeleteRestaurantPort,
+    private val saveInterestedRestaurantPort: SaveInterestedRestaurantPort,
+    private val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort,
 ) : AddInterestedRestaurantsUseCase, DeleteInterestedRestaurantsUseCase {
     @Transactional
     override fun addInterestedRestaurant(command: AddInterestedRestaurantCommand) {
-        saveRestaurantPort.saveInterestedRestaurant(
+        saveInterestedRestaurantPort.saveInterestedRestaurant(
             memberId = command.memberId,
             restaurantId = command.restaurantId,
         )
@@ -24,7 +24,7 @@ class RestaurantService(
 
     @Transactional
     override fun deleteInterestedRestaurant(command: DeleteInterestedRestaurantCommand) {
-        deleteRestaurantPort.deleteInterestedRestaurant(
+        deleteInterestedRestaurantPort.deleteInterestedRestaurant(
             memberId = command.memberId,
             restaurantId = command.restaurantId,
         )

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
@@ -1,0 +1,32 @@
+package com.celuveat.restaurant.application
+
+import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
+import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
+import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RestaurantService(
+    private val saveRestaurantPort: SaveRestaurantPort,
+    private val deleteRestaurantPort: DeleteRestaurantPort,
+) : AddInterestedRestaurantsUseCase, DeleteInterestedRestaurantsUseCase {
+    @Transactional
+    override fun addInterestedRestaurant(command: AddInterestedRestaurantCommand) {
+        saveRestaurantPort.saveInterestedRestaurant(
+            memberId = command.memberId,
+            restaurantId = command.restaurantId,
+        )
+    }
+
+    @Transactional
+    override fun deleteInterestedRestaurant(command: DeleteInterestedRestaurantCommand) {
+        deleteRestaurantPort.deleteInterestedRestaurant(
+            memberId = command.memberId,
+            restaurantId = command.restaurantId,
+        )
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
@@ -6,7 +6,7 @@ import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurants
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
 import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
 import org.springframework.stereotype.Service
@@ -16,12 +16,12 @@ import org.springframework.transaction.annotation.Transactional
 class RestaurantService(
     private val saveInterestedRestaurantPort: SaveInterestedRestaurantPort,
     private val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort,
-    private val findInterestedRestaurantPort: FindInterestedRestaurantPort,
+    private val readInterestedRestaurantPort: ReadInterestedRestaurantPort,
 ) : AddInterestedRestaurantsUseCase, DeleteInterestedRestaurantsUseCase {
     @Transactional
     override fun addInterestedRestaurant(command: AddInterestedRestaurantCommand) {
         throwWhen(
-            findInterestedRestaurantPort.existsInterestedRestaurant(command.memberId, command.restaurantId)
+            readInterestedRestaurantPort.existsInterestedRestaurant(command.memberId, command.restaurantId)
         ) { AlreadyInterestedRestaurantException }
         saveInterestedRestaurantPort.saveInterestedRestaurant(
             memberId = command.memberId,

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
@@ -1,11 +1,14 @@
 package com.celuveat.restaurant.application
 
+import com.celuveat.common.utils.throwWhen
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
+import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,9 +16,13 @@ import org.springframework.transaction.annotation.Transactional
 class RestaurantService(
     private val saveInterestedRestaurantPort: SaveInterestedRestaurantPort,
     private val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort,
+    private val findInterestedRestaurantPort: FindInterestedRestaurantPort,
 ) : AddInterestedRestaurantsUseCase, DeleteInterestedRestaurantsUseCase {
     @Transactional
     override fun addInterestedRestaurant(command: AddInterestedRestaurantCommand) {
+        throwWhen(
+            findInterestedRestaurantPort.existsInterestedRestaurant(command.memberId, command.restaurantId)
+        ) { AlreadyInterestedRestaurantException }
         saveInterestedRestaurantPort.saveInterestedRestaurant(
             memberId = command.memberId,
             restaurantId = command.restaurantId,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadCelebrityVisitedRestaurantUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadCelebrityVisitedRestaurantUseCase.kt
@@ -1,0 +1,9 @@
+package com.celuveat.restaurant.application.port.`in`
+
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
+
+interface ReadCelebrityVisitedRestaurantUseCase {
+    fun readCelebrityVisitedRestaurant(query: ReadCelebrityVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadInterestedRestaurantsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadInterestedRestaurantsUseCase.kt
@@ -4,6 +4,6 @@ import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 
-interface GetInterestedRestaurantsUseCase {
+interface ReadInterestedRestaurantsUseCase {
     fun getInterestedRestaurant(query: GetInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
@@ -3,5 +3,5 @@ package com.celuveat.restaurant.application.port.`in`
 import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
 
 interface ReadVisitedRestaurantUseCase {
-    fun readVisitedRestaurant(command: ReadVisitedRestaurantQuery)
+    fun readVisitedRestaurant(query: ReadVisitedRestaurantQuery)
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
@@ -1,7 +1,9 @@
 package com.celuveat.restaurant.application.port.`in`
 
+import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 
 interface ReadVisitedRestaurantUseCase {
-    fun readVisitedRestaurant(query: ReadVisitedRestaurantQuery)
+    fun readVisitedRestaurant(query: ReadVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.application.port.`in`
+
+import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
+
+interface ReadVisitedRestaurantUseCase {
+    fun readVisitedRestaurant(command: ReadVisitedRestaurantQuery)
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadVisitedRestaurantUseCase.kt
@@ -1,9 +1,0 @@
-package com.celuveat.restaurant.application.port.`in`
-
-import com.celuveat.common.application.port.`in`.result.SliceResult
-import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
-import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
-
-interface ReadVisitedRestaurantUseCase {
-    fun readVisitedRestaurant(query: ReadVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult>
-}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
@@ -2,7 +2,7 @@ package com.celuveat.restaurant.application.port.`in`.query
 
 const val DEFAULT_VISITED_RESTAURANTS_SIZE = 10
 
-data class ReadVisitedRestaurantQuery(
+data class ReadCelebrityVisitedRestaurantQuery(
     val memberId: Long?,
     val celebrityId: Long,
     val page: Int = 0,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadVisitedRestaurantQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadVisitedRestaurantQuery.kt
@@ -1,0 +1,10 @@
+package com.celuveat.restaurant.application.port.`in`.query
+
+const val DEFAULT_VISITED_RESTAURANTS_SIZE = 10
+
+data class ReadVisitedRestaurantQuery(
+    val memberId: Long?,
+    val celebrityId: Long,
+    val page: Int = 0,
+    val size: Int = DEFAULT_VISITED_RESTAURANTS_SIZE,
+)

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
@@ -22,7 +22,7 @@ data class RestaurantPreviewResult(
         fun of(
             restaurant: Restaurant,
             liked: Boolean,
-            visitedCelebrities: List<Celebrity>,
+            visitedCelebrities: List<Celebrity> = emptyList(),
         ): RestaurantPreviewResult {
             return RestaurantPreviewResult(
                 id = restaurant.id,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
@@ -34,7 +34,7 @@ data class RestaurantPreviewResult(
                 latitude = restaurant.latitude,
                 longitude = restaurant.longitude,
                 liked = liked,
-                visitedCelebrities = visitedCelebrities.map { SimpleCelebrityResult(it.name, it.profileImageUrl) },
+                visitedCelebrities = visitedCelebrities.map { SimpleCelebrityResult.from(it) },
                 images = restaurant.images.map { RestaurantImageResult.from(it) },
             )
         }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/DeleteInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/DeleteInterestedRestaurantPort.kt
@@ -1,6 +1,6 @@
 package com.celuveat.restaurant.application.port.out
 
-interface DeleteRestaurantPort {
+interface DeleteInterestedRestaurantPort {
     fun deleteInterestedRestaurant(
         memberId: Long,
         restaurantId: Long,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
@@ -17,6 +17,6 @@ interface FindInterestedRestaurantPort {
 
     fun findInterestedRestaurantsByIds(
         memberId: Long,
-        restaurantIds: List<Long>
+        restaurantIds: List<Long>,
     ): List<InterestedRestaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
@@ -10,10 +10,10 @@ interface FindInterestedRestaurantPort {
         size: Int,
     ): SliceResult<InterestedRestaurant>
 
-    fun findInterestedRestaurantOrNull(
+    fun existsInterestedRestaurant(
         memberId: Long,
         restaurantId: Long,
-    ): InterestedRestaurant?
+    ): Boolean
 
     fun findInterestedRestaurantsByIds(
         memberId: Long,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
@@ -1,0 +1,17 @@
+package com.celuveat.restaurant.application.port.out
+
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.domain.InterestedRestaurant
+
+interface FindInterestedRestaurantPort {
+    fun findInterestedRestaurants(
+        memberId: Long,
+        page: Int,
+        size: Int,
+    ): SliceResult<InterestedRestaurant>
+
+    fun findInterestedRestaurantOrNull(
+        memberId: Long,
+        restaurantId: Long,
+    ): InterestedRestaurant?
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindInterestedRestaurantPort.kt
@@ -14,4 +14,9 @@ interface FindInterestedRestaurantPort {
         memberId: Long,
         restaurantId: Long,
     ): InterestedRestaurant?
+
+    fun findInterestedRestaurantsByIds(
+        memberId: Long,
+        restaurantIds: List<Long>
+    ): List<InterestedRestaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantPort.kt
@@ -9,6 +9,4 @@ interface FindRestaurantPort {
         page: Int,
         size: Int,
     ): SliceResult<Restaurant>
-
-    fun findInterestedRestaurantsByIds(restaurantIds: List<Long>): List<Restaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantPort.kt
@@ -14,4 +14,10 @@ interface FindRestaurantPort {
         memberId: Long,
         restaurantId: Long,
     ): Restaurant?
+
+    fun findVisitedRestaurantByCelebrity(
+        celebrityId: Long,
+        page: Int,
+        size: Int,
+    ): SliceResult<Restaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/FindRestaurantPort.kt
@@ -4,20 +4,11 @@ import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.domain.Restaurant
 
 interface FindRestaurantPort {
-    fun findInterestedRestaurants(
-        memberId: Long,
-        page: Int,
-        size: Int,
-    ): SliceResult<Restaurant>
-
-    fun findInterestedRestaurantOrNull(
-        memberId: Long,
-        restaurantId: Long,
-    ): Restaurant?
-
     fun findVisitedRestaurantByCelebrity(
         celebrityId: Long,
         page: Int,
         size: Int,
     ): SliceResult<Restaurant>
+
+    fun findInterestedRestaurantsByIds(restaurantIds: List<Long>): List<Restaurant>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadInterestedRestaurantPort.kt
@@ -3,7 +3,7 @@ package com.celuveat.restaurant.application.port.out
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.domain.InterestedRestaurant
 
-interface FindInterestedRestaurantPort {
+interface ReadInterestedRestaurantPort {
     fun findInterestedRestaurants(
         memberId: Long,
         page: Int,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -3,7 +3,7 @@ package com.celuveat.restaurant.application.port.out
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.domain.Restaurant
 
-interface FindRestaurantPort {
+interface ReadRestaurantPort {
     fun findVisitedRestaurantByCelebrity(
         celebrityId: Long,
         page: Int,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/SaveInterestedRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/SaveInterestedRestaurantPort.kt
@@ -1,6 +1,6 @@
 package com.celuveat.restaurant.application.port.out
 
-interface SaveRestaurantPort {
+interface SaveInterestedRestaurantPort {
     fun saveInterestedRestaurant(
         memberId: Long,
         restaurantId: Long,

--- a/src/main/kotlin/com/celuveat/restaurant/domain/InterestedRestaurant.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/domain/InterestedRestaurant.kt
@@ -1,0 +1,8 @@
+package com.celuveat.restaurant.domain
+
+import com.celuveat.member.domain.Member
+
+data class InterestedRestaurant(
+    val member: Member,
+    val restaurant: Restaurant,
+)

--- a/src/test/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityControllerTest.kt
@@ -1,13 +1,13 @@
 package com.celuveat.celeb.adapter.`in`.rest
 
 import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
-import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
-import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
 import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.support.sut

--- a/src/test/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityControllerTest.kt
@@ -3,10 +3,13 @@ package com.celuveat.celeb.adapter.`in`.rest
 import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
+import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.support.sut
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
@@ -27,6 +30,7 @@ class CelebrityControllerTest(
     @MockkBean val getInterestedCelebritiesUseCase: GetInterestedCelebritiesUseCase,
     @MockkBean val addInterestedCelebrityUseCase: AddInterestedCelebrityUseCase,
     @MockkBean val deleteInterestedCelebrityUseCase: DeleteInterestedCelebrityUseCase,
+    @MockkBean val readBestCelebritiesUseCase: ReadBestCelebritiesUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({
@@ -85,6 +89,22 @@ class CelebrityControllerTest(
                 header("Authorization", "Bearer $accessToken")
             }.andExpect {
                 status { isOk() }
+            }.andDo {
+                print()
+            }
+        }
+    }
+
+    context("인기 셀럽을 조회 한다") {
+        val results = sut.giveMeBuilder<SimpleCelebrityResult>()
+            .sampleList(3)
+        val response = results.map { SimpleCelebrityResponse.from(it) }
+        test("조회 성공") {
+            every { readBestCelebritiesUseCase.readBestCelebrities() } returns results
+
+            mockMvc.get("/celebrities/best").andExpect {
+                status { isOk() }
+                content { json(mapper.writeValueAsString(response)) }
             }.andDo {
                 print()
             }

--- a/src/test/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityControllerTest.kt
@@ -4,8 +4,8 @@ import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
-import com.celuveat.celeb.application.port.`in`.GetInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.post
 class CelebrityControllerTest(
     @Autowired val mockMvc: MockMvc,
     @Autowired val mapper: ObjectMapper,
-    @MockkBean val getInterestedCelebritiesUseCase: GetInterestedCelebritiesUseCase,
+    @MockkBean val readInterestedCelebritiesUseCase: ReadInterestedCelebritiesUseCase,
     @MockkBean val addInterestedCelebrityUseCase: AddInterestedCelebrityUseCase,
     @MockkBean val deleteInterestedCelebrityUseCase: DeleteInterestedCelebrityUseCase,
     @MockkBean val readBestCelebritiesUseCase: ReadBestCelebritiesUseCase,
@@ -42,7 +42,7 @@ class CelebrityControllerTest(
             .sampleList(3)
         test("조회 성공") {
             every { extractMemberIdUseCase.extract(accessToken) } returns memberId
-            every { getInterestedCelebritiesUseCase.getInterestedCelebrities(memberId) } returns results
+            every { readInterestedCelebritiesUseCase.getInterestedCelebrities(memberId) } returns results
 
             mockMvc.get("/celebrities/interested") {
                 header("Authorization", "Bearer $accessToken")

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -52,7 +52,7 @@ class CelebrityPersistenceAdapterTest(
             listOf(
                 generateCelebrityYoutubeContent(celebrityA, savedContents[0]),
                 generateCelebrityYoutubeContent(celebrityA, savedContents[1]),
-                generateCelebrityYoutubeContent(celebrityB, savedContents[2]),
+                generateCelebrityYoutubeContent(celebrityB, savedContents[0]),
             ),
         ) // [셀럽A] -> [컨텐츠A, 컨텐츠B], [셀럽B] -> [컨텐츠A] 에 출연함
 

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -19,6 +19,7 @@ import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.set
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
@@ -49,18 +50,9 @@ class CelebrityPersistenceAdapterTest(
         val savedContents = youtubeContentJpaRepository.saveAll(listOf(contentA, contentB))
         celebrityYoutubeContentJpaRepository.saveAll(
             listOf(
-                sut.giveMeBuilder<CelebrityYoutubeContentJpaEntity>()
-                    .set(CelebrityYoutubeContentJpaEntity::celebrity, celebrityA)
-                    .set(CelebrityYoutubeContentJpaEntity::youtubeContent, savedContents[0])
-                    .sample(),
-                sut.giveMeBuilder<CelebrityYoutubeContentJpaEntity>()
-                    .set(CelebrityYoutubeContentJpaEntity::celebrity, celebrityA)
-                    .set(CelebrityYoutubeContentJpaEntity::youtubeContent, savedContents[1])
-                    .sample(),
-                sut.giveMeBuilder<CelebrityYoutubeContentJpaEntity>()
-                    .set(CelebrityYoutubeContentJpaEntity::celebrity, celebrityB)
-                    .set(CelebrityYoutubeContentJpaEntity::youtubeContent, savedContents[0])
-                    .sample(),
+                generateCelebrityYoutubeContent(celebrityA, savedContents[0]),
+                generateCelebrityYoutubeContent(celebrityA, savedContents[1]),
+                generateCelebrityYoutubeContent(celebrityB, savedContents[2]),
             ),
         ) // [셀럽A] -> [컨텐츠A, 컨텐츠B], [셀럽B] -> [컨텐츠A] 에 출연함
 
@@ -101,7 +93,61 @@ class CelebrityPersistenceAdapterTest(
             visitedCelebritiesByRestaurants[restaurants[1].id]!!.size shouldBe 1
         }
     }
+
+    "구독자가 많은 컨텐츠의 셀럽순으로 조회 한다." {
+        // given
+        val savedCelebrities = celebrityJpaRepository.saveAll(sut.giveMeBuilder<CelebrityJpaEntity>().sampleList(3))
+        val celebrityA = savedCelebrities[0]
+        val celebrityB = savedCelebrities[1]
+        val celebrityC = savedCelebrities[2]
+
+        val contentA = sut.giveMeBuilder<YoutubeContentJpaEntity>()
+            .set(YoutubeContentJpaEntity::id, 0)
+            .set(YoutubeContentJpaEntity::channelId, "@channelId")
+            .set(YoutubeContentJpaEntity::subscriberCount, 300)
+            .sample()
+        val contentB = sut.giveMeBuilder<YoutubeContentJpaEntity>()
+            .set(YoutubeContentJpaEntity::id, 0)
+            .set(YoutubeContentJpaEntity::channelId, "@channelId")
+            .set(YoutubeContentJpaEntity::subscriberCount, 200)
+            .sample()
+        val contentC = sut.giveMeBuilder<YoutubeContentJpaEntity>()
+            .set(YoutubeContentJpaEntity::id, 0)
+            .set(YoutubeContentJpaEntity::channelId, "@channelId")
+            .set(YoutubeContentJpaEntity::subscriberCount, 500)
+            .sample()
+        val contentD = sut.giveMeBuilder<YoutubeContentJpaEntity>()
+            .set(YoutubeContentJpaEntity::id, 0)
+            .set(YoutubeContentJpaEntity::channelId, "@channelId")
+            .set(YoutubeContentJpaEntity::subscriberCount, 400)
+            .sample()
+        val savedContents = youtubeContentJpaRepository.saveAll(listOf(contentA, contentB, contentC, contentD))
+        celebrityYoutubeContentJpaRepository.saveAll(
+            listOf(
+                generateCelebrityYoutubeContent(celebrityA, savedContents[0]),
+                generateCelebrityYoutubeContent(celebrityB, savedContents[1]),
+                generateCelebrityYoutubeContent(celebrityC, savedContents[2]),
+                generateCelebrityYoutubeContent(celebrityA, savedContents[3]),
+            ),
+        )
+
+        // when
+        val celebrities = celebrityPersistenceAdapter.findBestCelebrities()
+
+        // then
+        celebrities.size shouldBe 3
+        celebrities.map { it.id } shouldContainExactly listOf(celebrityC.id, celebrityA.id, celebrityB.id)
+    }
 })
+
+private fun generateCelebrityYoutubeContent(
+    celebrity: CelebrityJpaEntity?,
+    savedContent: YoutubeContentJpaEntity,
+): CelebrityYoutubeContentJpaEntity =
+    sut.giveMeBuilder<CelebrityYoutubeContentJpaEntity>()
+        .set(CelebrityYoutubeContentJpaEntity::celebrity, celebrity)
+        .set(CelebrityYoutubeContentJpaEntity::youtubeContent, savedContent)
+        .sample()
 
 private fun generateVideoWithYoutubeContent(youtubeContent: YoutubeContentJpaEntity) =
     sut.giveMeBuilder<VideoJpaEntity>().set(VideoJpaEntity::youtubeContent, youtubeContent)

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -94,7 +94,7 @@ class CelebrityPersistenceAdapterTest(
         }
     }
 
-    "구독자가 많은 컨텐츠의 셀럽순으로 조회 한다." {
+    test("구독자가 많은 컨텐츠의 셀럽순으로 조회 한다.") {
         // given
         val savedCelebrities = celebrityJpaRepository.saveAll(sut.giveMeBuilder<CelebrityJpaEntity>().sampleList(3))
         val celebrityA = savedCelebrities[0]

--- a/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginControllerTest.kt
@@ -3,7 +3,7 @@ package com.celuveat.member.adapter.`in`.rest
 import com.celuveat.auth.application.port.`in`.CreateAccessTokenUseCase
 import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.auth.domain.Token
-import com.celuveat.member.application.port.`in`.GetSocialLoginUrlUseCase
+import com.celuveat.member.application.port.`in`.ReadSocialLoginUrlUseCase
 import com.celuveat.member.application.port.`in`.SocialLoginUseCase
 import com.celuveat.member.application.port.`in`.WithdrawSocialLoginUseCase
 import com.celuveat.member.application.port.`in`.command.SocialLoginCommand
@@ -27,7 +27,7 @@ class SocialLoginControllerTest(
     @Autowired val mockMvc: MockMvc,
     @MockkBean val socialLoginUseCase: SocialLoginUseCase,
     @MockkBean val createAccessTokenUseCase: CreateAccessTokenUseCase,
-    @MockkBean val getSocialLoginUrlUseCase: GetSocialLoginUrlUseCase,
+    @MockkBean val readSocialLoginUrlUseCase: ReadSocialLoginUrlUseCase,
     @MockkBean val withdrawSocialLoginUseCase: WithdrawSocialLoginUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
@@ -73,7 +73,7 @@ class SocialLoginControllerTest(
         val socialLoginUrl = "https://social.com/authorize?redirect_uri=$requestOrigin/oauth/kakao&client_id=clientId"
 
         test("소셜 로그인 URL을 성공적으로 반환한다") {
-            every { getSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin) } returns socialLoginUrl
+            every { readSocialLoginUrlUseCase.getSocialLoginUrl(socialLoginType, requestOrigin) } returns socialLoginUrl
 
             mockMvc.get("/social-login/url/{socialLoginType}", socialLoginType) {
                 header("Origin", requestOrigin)

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -4,7 +4,7 @@ import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.GetInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
@@ -33,7 +33,7 @@ import org.springframework.test.web.servlet.post
 class RestaurantControllerTest(
     @Autowired val mockMvc: MockMvc,
     @Autowired val mapper: ObjectMapper,
-    @MockkBean val getInterestedRestaurantsUseCase: GetInterestedRestaurantsUseCase,
+    @MockkBean val readInterestedRestaurantsUseCase: ReadInterestedRestaurantsUseCase,
     @MockkBean val addInterestedRestaurantsUseCase: AddInterestedRestaurantsUseCase,
     @MockkBean val deleteInterestedRestaurantsUseCase: DeleteInterestedRestaurantsUseCase,
     @MockkBean val readVisitedRestaurantUseCase: ReadVisitedRestaurantUseCase,
@@ -54,7 +54,7 @@ class RestaurantControllerTest(
         test("조회 성공") {
             val query = GetInterestedRestaurantsQuery(memberId, page, size = 3)
             every { extractMemberIdUseCase.extract(accessToken) } returns memberId
-            every { getInterestedRestaurantsUseCase.getInterestedRestaurant(query) } returns results
+            every { readInterestedRestaurantsUseCase.getInterestedRestaurant(query) } returns results
 
             mockMvc.get("/restaurants/interested") {
                 header("Authorization", "Bearer $accessToken")

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -4,12 +4,12 @@ import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
-import com.celuveat.restaurant.application.port.`in`.ReadVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 import com.celuveat.support.sut
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -36,7 +36,7 @@ class RestaurantControllerTest(
     @MockkBean val readInterestedRestaurantsUseCase: ReadInterestedRestaurantsUseCase,
     @MockkBean val addInterestedRestaurantsUseCase: AddInterestedRestaurantsUseCase,
     @MockkBean val deleteInterestedRestaurantsUseCase: DeleteInterestedRestaurantsUseCase,
-    @MockkBean val readVisitedRestaurantUseCase: ReadVisitedRestaurantUseCase,
+    @MockkBean val readCelebrityVisitedRestaurantUseCase: ReadCelebrityVisitedRestaurantUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({
@@ -122,9 +122,9 @@ class RestaurantControllerTest(
                 currentPage = page,
                 hasNext = false,
             )
-            val query = ReadVisitedRestaurantQuery(memberId, celebrityId, page, size = 3)
+            val query = ReadCelebrityVisitedRestaurantQuery(memberId, celebrityId, page, size = 3)
             every { extractMemberIdUseCase.extract(accessToken) } returns memberId
-            every { readVisitedRestaurantUseCase.readVisitedRestaurant(query) } returns results
+            every { readCelebrityVisitedRestaurantUseCase.readCelebrityVisitedRestaurant(query) } returns results
 
             mockMvc.get("/restaurants/celebrity/$celebrityId") {
                 header("Authorization", "Bearer $accessToken")
@@ -146,8 +146,8 @@ class RestaurantControllerTest(
                 currentPage = page,
                 hasNext = false,
             )
-            val query = ReadVisitedRestaurantQuery(null, celebrityId, page, size = 3)
-            every { readVisitedRestaurantUseCase.readVisitedRestaurant(query) } returns results
+            val query = ReadCelebrityVisitedRestaurantQuery(null, celebrityId, page, size = 3)
+            every { readCelebrityVisitedRestaurantUseCase.readCelebrityVisitedRestaurant(query) } returns results
 
             mockMvc.get("/restaurants/celebrity/$celebrityId") {
                 param("page", page.toString())

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapterTest.kt
@@ -1,0 +1,218 @@
+package com.celuveat.restaurant.adapter.out.persistence
+
+import com.celuveat.common.adapter.out.persistence.JpaConfig
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
+import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
+import com.celuveat.member.adapter.out.persistence.entity.MemberPersistenceMapper
+import com.celuveat.member.exception.NotFoundMemberException
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantPersistenceMapper
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
+import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
+import com.celuveat.restaurant.exception.NotFoundInterestedRestaurantException
+import com.celuveat.restaurant.exception.NotFoundRestaurantException
+import com.celuveat.support.sut
+import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import com.navercorp.fixturemonkey.kotlin.set
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+private const val NOT_EXIST_ID = -1L
+
+@Import(
+    InterestedRestaurantPersistenceAdapter::class,
+    InterestedRestaurantPersistenceMapper::class,
+    RestaurantPersistenceMapper::class,
+    MemberPersistenceMapper::class,
+    JpaConfig::class
+)
+@DataJpaTest
+class InterestedRestaurantPersistenceAdapterTest(
+    private val restaurantPersistenceAdapter: InterestedRestaurantPersistenceAdapter,
+    private val restaurantJpaRepository: RestaurantJpaRepository,
+    private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
+    private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
+    private val memberJpaRepository: MemberJpaRepository,
+) : FunSpec({
+    context("회원이 관심 목록에 추가한 음식점을 조회 한다.") {
+        // given
+        val savedRestaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(2))
+        val restaurantA = savedRestaurants[0]
+        val restaurantB = savedRestaurants[1]
+
+        val imagesA = sut.giveMeBuilder<RestaurantImageJpaEntity>()
+            .set(RestaurantImageJpaEntity::id, 0)
+            .set(RestaurantImageJpaEntity::restaurant, restaurantA)
+            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+            .sampleList(3)
+        val imagesB = sut.giveMeBuilder<RestaurantImageJpaEntity>()
+            .set(RestaurantImageJpaEntity::id, 0)
+            .set(RestaurantImageJpaEntity::restaurant, restaurantB)
+            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+            .sampleList(2)
+        restaurantImageJpaRepository.saveAll(imagesA + imagesB)
+
+        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
+        interestedRestaurantJpaRepository.saveAll(
+            listOf(
+                sut.giveMeBuilder<InterestedRestaurantJpaEntity>()
+                    .set(InterestedRestaurantJpaEntity::member, savedMember)
+                    .set(InterestedRestaurantJpaEntity::restaurant, savedRestaurants[0])
+                    .sample(),
+                sut.giveMeBuilder<InterestedRestaurantJpaEntity>()
+                    .set(InterestedRestaurantJpaEntity::member, savedMember)
+                    .set(InterestedRestaurantJpaEntity::restaurant, savedRestaurants[1])
+                    .sample(),
+            ),
+        )
+
+        test("추가로 조회할 수 있는 음식점의 여부를 응답한다") {
+            // when
+            val interestedRestaurantResults = restaurantPersistenceAdapter.findInterestedRestaurants(
+                savedMember.id,
+                0,
+                1,
+            )
+
+            // then
+            interestedRestaurantResults.size shouldBe 1
+            interestedRestaurantResults.hasNext shouldBe true
+            interestedRestaurantResults.contents.map { it.restaurant.id } shouldBe listOf(restaurantB.id)
+        }
+
+        test("마지막 음식점을 조회한 경우 hasNext는 false를 응답한다") {
+            // when
+            val interestedRestaurantResults = restaurantPersistenceAdapter.findInterestedRestaurants(
+                savedMember.id,
+                0,
+                2,
+            )
+
+            // then
+            interestedRestaurantResults.size shouldBe 2
+            interestedRestaurantResults.hasNext shouldBe false
+            interestedRestaurantResults.contents.map { it.restaurant.id } shouldContainInOrder listOf(
+                restaurantB.id,
+                restaurantA.id,
+            )
+        }
+    }
+
+    context("관심 음식점 조회 시") {
+        // given
+        val savedRestaurant = restaurantJpaRepository.save(sut.giveMeOne<RestaurantJpaEntity>())
+        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
+        val images = sut.giveMeBuilder<RestaurantImageJpaEntity>()
+            .set(RestaurantImageJpaEntity::id, 0)
+            .set(RestaurantImageJpaEntity::restaurant, savedRestaurant)
+            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+            .sampleList(3)
+        restaurantImageJpaRepository.saveAll(images)
+        interestedRestaurantJpaRepository.save(
+            InterestedRestaurantJpaEntity(
+                member = savedMember,
+                restaurant = savedRestaurant,
+            ),
+        )
+
+        test("존재하는 관심 음식점인 경우 음식점을 반환한다.") {
+            // when
+            val interestedRestaurant = restaurantPersistenceAdapter.findInterestedRestaurantOrNull(
+                savedMember.id,
+                savedRestaurant.id,
+            )
+
+            // then
+            interestedRestaurant!!.restaurant.id shouldBe savedRestaurant.id
+        }
+
+        test("존재하지 않는 관심 음식점인 경우 null을 반환한다.") {
+            // when
+            val interestedRestaurant = restaurantPersistenceAdapter.findInterestedRestaurantOrNull(
+                savedMember.id,
+                NOT_EXIST_ID,
+            )
+
+            // then
+            interestedRestaurant shouldBe null
+        }
+    }
+
+    context("관심 음식점 등록 시") {
+        // given
+        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
+        val savedRestaurant = restaurantJpaRepository.save(sut.giveMeOne<RestaurantJpaEntity>())
+
+        test("관심 음식점을 등록한다.") {
+            // when & then
+            shouldNotThrowAny {
+                restaurantPersistenceAdapter.saveInterestedRestaurant(
+                    savedMember.id,
+                    savedRestaurant.id,
+                )
+            }
+        }
+
+        test("이미 등록된 관심 음식점인 경우 예외가 발생한다.") {
+            // when & then
+            shouldThrow<AlreadyInterestedRestaurantException> {
+                restaurantPersistenceAdapter.saveInterestedRestaurant(savedMember.id, savedRestaurant.id)
+                restaurantPersistenceAdapter.saveInterestedRestaurant(savedMember.id, savedRestaurant.id)
+            }
+        }
+
+        test("존재 하지 않는 회원인 경우 예외가 발생한다.") {
+            // when & then
+            shouldThrow<NotFoundMemberException> {
+                restaurantPersistenceAdapter.saveInterestedRestaurant(NOT_EXIST_ID, savedRestaurant.id)
+            }
+        }
+
+        test("존재 하지 않는 음식점인 경우 예외가 발생한다.") {
+            // when & then
+            shouldThrow<NotFoundRestaurantException> {
+                restaurantPersistenceAdapter.saveInterestedRestaurant(savedMember.id, NOT_EXIST_ID)
+            }
+        }
+    }
+
+    context("관심 음식점 삭제 시") {
+        // given
+        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
+        val savedRestaurant = restaurantJpaRepository.save(sut.giveMeOne<RestaurantJpaEntity>())
+        interestedRestaurantJpaRepository.save(
+            InterestedRestaurantJpaEntity(
+                member = savedMember,
+                restaurant = savedRestaurant,
+            ),
+        )
+
+        test("관심 음식점을 삭제한다.") {
+            // when & then
+            shouldNotThrowAny {
+                restaurantPersistenceAdapter.deleteInterestedRestaurant(
+                    savedMember.id,
+                    savedRestaurant.id,
+                )
+            }
+        }
+
+        test("존재하지 않는 관심 음식점인 경우 예외를 발생한다.") {
+            // when & then
+            shouldThrow<NotFoundInterestedRestaurantException> {
+                restaurantPersistenceAdapter.deleteInterestedRestaurant(savedMember.id, NOT_EXIST_ID)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/InterestedRestaurantPersistenceAdapterTest.kt
@@ -37,7 +37,7 @@ private const val NOT_EXIST_ID = -1L
     InterestedRestaurantPersistenceMapper::class,
     RestaurantPersistenceMapper::class,
     MemberPersistenceMapper::class,
-    JpaConfig::class
+    JpaConfig::class,
 )
 @DataJpaTest
 class InterestedRestaurantPersistenceAdapterTest(

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -1,5 +1,8 @@
 package com.celuveat.restaurant.adapter.out.persistence
 
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaEntity
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.common.adapter.out.persistence.JpaConfig
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
@@ -35,6 +38,8 @@ class RestaurantPersistenceAdapterTest(
     private val restaurantJpaRepository: RestaurantJpaRepository,
     private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
     private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
+    private val celebrityJpaRepository: CelebrityJpaRepository,
+    private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
     private val memberJpaRepository: MemberJpaRepository,
 ) : FunSpec({
 
@@ -206,6 +211,45 @@ class RestaurantPersistenceAdapterTest(
             shouldThrow<NotFoundInterestedRestaurantException> {
                 restaurantPersistenceAdapter.deleteInterestedRestaurant(savedMember.id, NOT_EXIST_ID)
             }
+        }
+    }
+
+    context("셀럽 기준으로 음식점 조회 시") {
+        // given
+        val savedRestaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(3))
+        val savedCelebrity = celebrityJpaRepository.save(sut.giveMeOne())
+        celebrityRestaurantJpaRepository.saveAll(
+            savedRestaurants.map {
+                CelebrityRestaurantJpaEntity(
+                    celebrity = savedCelebrity,
+                    restaurant = it,
+                )
+            },
+        )
+
+        restaurantImageJpaRepository.saveAll(savedRestaurants.map {
+            sut.giveMeBuilder<RestaurantImageJpaEntity>()
+                .set(RestaurantImageJpaEntity::id, 0)
+                .set(RestaurantImageJpaEntity::restaurant, it)
+                .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+                .sampleList(3)
+        }.flatten())
+
+        test("셀럽이 방문한 음식점을 조회한다.") {
+            // when
+            val visitedRestaurants = restaurantPersistenceAdapter.findVisitedRestaurantByCelebrity(
+                celebrityId = savedCelebrity.id,
+                page = 0,
+                size = 2,
+            )
+
+            // then
+            visitedRestaurants.size shouldBe 2
+            visitedRestaurants.contents.map { it.id } shouldContainInOrder listOf(
+                savedRestaurants[2].id,
+                savedRestaurants[1].id,
+            )
+            visitedRestaurants.hasNext shouldBe true
         }
     }
 })

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -4,25 +4,15 @@ import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.common.adapter.out.persistence.JpaConfig
-import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
-import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
-import com.celuveat.member.exception.NotFoundMemberException
-import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
-import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaEntity
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
-import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
-import com.celuveat.restaurant.exception.NotFoundInterestedRestaurantException
-import com.celuveat.restaurant.exception.NotFoundRestaurantException
 import com.celuveat.support.sut
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.navercorp.fixturemonkey.kotlin.set
-import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
@@ -36,184 +26,10 @@ private const val NOT_EXIST_ID = -1L
 class RestaurantPersistenceAdapterTest(
     private val restaurantPersistenceAdapter: RestaurantPersistenceAdapter,
     private val restaurantJpaRepository: RestaurantJpaRepository,
-    private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
     private val restaurantImageJpaRepository: RestaurantImageJpaRepository,
     private val celebrityJpaRepository: CelebrityJpaRepository,
     private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
-    private val memberJpaRepository: MemberJpaRepository,
 ) : FunSpec({
-
-    context("회원이 관심 목록에 추가한 음식점을 조회 한다.") {
-        // given
-        val savedRestaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(2))
-        val restaurantA = savedRestaurants[0]
-        val restaurantB = savedRestaurants[1]
-
-        val imagesA = sut.giveMeBuilder<RestaurantImageJpaEntity>()
-            .set(RestaurantImageJpaEntity::id, 0)
-            .set(RestaurantImageJpaEntity::restaurant, restaurantA)
-            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
-            .sampleList(3)
-        val imagesB = sut.giveMeBuilder<RestaurantImageJpaEntity>()
-            .set(RestaurantImageJpaEntity::id, 0)
-            .set(RestaurantImageJpaEntity::restaurant, restaurantB)
-            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
-            .sampleList(2)
-        restaurantImageJpaRepository.saveAll(imagesA + imagesB)
-
-        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
-        interestedRestaurantJpaRepository.saveAll(
-            listOf(
-                sut.giveMeBuilder<InterestedRestaurantJpaEntity>()
-                    .set(InterestedRestaurantJpaEntity::member, savedMember)
-                    .set(InterestedRestaurantJpaEntity::restaurant, savedRestaurants[0])
-                    .sample(),
-                sut.giveMeBuilder<InterestedRestaurantJpaEntity>()
-                    .set(InterestedRestaurantJpaEntity::member, savedMember)
-                    .set(InterestedRestaurantJpaEntity::restaurant, savedRestaurants[1])
-                    .sample(),
-            ),
-        )
-
-        test("추가로 조회할 수 있는 음식점의 여부를 응답한다") {
-            // when
-            val interestedRestaurantResults = restaurantPersistenceAdapter.findInterestedRestaurants(
-                savedMember.id,
-                0,
-                1,
-            )
-
-            // then
-            interestedRestaurantResults.size shouldBe 1
-            interestedRestaurantResults.hasNext shouldBe true
-            interestedRestaurantResults.contents.map { it.id } shouldBe listOf(restaurantB.id)
-        }
-
-        test("마지막 음식점을 조회한 경우 hasNext는 false를 응답한다") {
-            // when
-            val interestedRestaurantResults = restaurantPersistenceAdapter.findInterestedRestaurants(
-                savedMember.id,
-                0,
-                2,
-            )
-
-            // then
-            interestedRestaurantResults.size shouldBe 2
-            interestedRestaurantResults.hasNext shouldBe false
-            interestedRestaurantResults.contents.map { it.id } shouldContainInOrder listOf(
-                restaurantB.id,
-                restaurantA.id,
-            )
-        }
-    }
-
-    context("관심 음식점 조회 시") {
-        // given
-        val savedRestaurant = restaurantJpaRepository.save(sut.giveMeOne<RestaurantJpaEntity>())
-        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
-        val images = sut.giveMeBuilder<RestaurantImageJpaEntity>()
-            .set(RestaurantImageJpaEntity::id, 0)
-            .set(RestaurantImageJpaEntity::restaurant, savedRestaurant)
-            .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
-            .sampleList(3)
-        restaurantImageJpaRepository.saveAll(images)
-        interestedRestaurantJpaRepository.save(
-            InterestedRestaurantJpaEntity(
-                member = savedMember,
-                restaurant = savedRestaurant,
-            ),
-        )
-
-        test("존재하는 관심 음식점인 경우 음식점을 반환한다.") {
-            // when
-            val interestedRestaurant = restaurantPersistenceAdapter.findInterestedRestaurantOrNull(
-                savedMember.id,
-                savedRestaurant.id,
-            )
-
-            // then
-            interestedRestaurant!!.id shouldBe savedRestaurant.id
-        }
-
-        test("존재하지 않는 관심 음식점인 경우 null을 반환한다.") {
-            // when
-            val interestedRestaurant = restaurantPersistenceAdapter.findInterestedRestaurantOrNull(
-                savedMember.id,
-                NOT_EXIST_ID,
-            )
-
-            // then
-            interestedRestaurant shouldBe null
-        }
-    }
-
-    context("관심 음식점 등록 시") {
-        // given
-        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
-        val savedRestaurant = restaurantJpaRepository.save(sut.giveMeOne<RestaurantJpaEntity>())
-
-        test("관심 음식점을 등록한다.") {
-            // when & then
-            shouldNotThrowAny {
-                restaurantPersistenceAdapter.saveInterestedRestaurant(
-                    savedMember.id,
-                    savedRestaurant.id,
-                )
-            }
-        }
-
-        test("이미 등록된 관심 음식점인 경우 예외가 발생한다.") {
-            // when & then
-            shouldThrow<AlreadyInterestedRestaurantException> {
-                restaurantPersistenceAdapter.saveInterestedRestaurant(savedMember.id, savedRestaurant.id)
-                restaurantPersistenceAdapter.saveInterestedRestaurant(savedMember.id, savedRestaurant.id)
-            }
-        }
-
-        test("존재 하지 않는 회원인 경우 예외가 발생한다.") {
-            // when & then
-            shouldThrow<NotFoundMemberException> {
-                restaurantPersistenceAdapter.saveInterestedRestaurant(NOT_EXIST_ID, savedRestaurant.id)
-            }
-        }
-
-        test("존재 하지 않는 음식점인 경우 예외가 발생한다.") {
-            // when & then
-            shouldThrow<NotFoundRestaurantException> {
-                restaurantPersistenceAdapter.saveInterestedRestaurant(savedMember.id, NOT_EXIST_ID)
-            }
-        }
-    }
-
-    context("관심 음식점 삭제 시") {
-        // given
-        val savedMember = memberJpaRepository.save(sut.giveMeOne<MemberJpaEntity>())
-        val savedRestaurant = restaurantJpaRepository.save(sut.giveMeOne<RestaurantJpaEntity>())
-        interestedRestaurantJpaRepository.save(
-            InterestedRestaurantJpaEntity(
-                member = savedMember,
-                restaurant = savedRestaurant,
-            ),
-        )
-
-        test("관심 음식점을 삭제한다.") {
-            // when & then
-            shouldNotThrowAny {
-                restaurantPersistenceAdapter.deleteInterestedRestaurant(
-                    savedMember.id,
-                    savedRestaurant.id,
-                )
-            }
-        }
-
-        test("존재하지 않는 관심 음식점인 경우 예외를 발생한다.") {
-            // when & then
-            shouldThrow<NotFoundInterestedRestaurantException> {
-                restaurantPersistenceAdapter.deleteInterestedRestaurant(savedMember.id, NOT_EXIST_ID)
-            }
-        }
-    }
-
     context("셀럽 기준으로 음식점 조회 시") {
         // given
         val savedRestaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(3))

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -43,13 +43,15 @@ class RestaurantPersistenceAdapterTest(
             },
         )
 
-        restaurantImageJpaRepository.saveAll(savedRestaurants.map {
-            sut.giveMeBuilder<RestaurantImageJpaEntity>()
-                .set(RestaurantImageJpaEntity::id, 0)
-                .set(RestaurantImageJpaEntity::restaurant, it)
-                .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
-                .sampleList(3)
-        }.flatten())
+        restaurantImageJpaRepository.saveAll(
+            savedRestaurants.map {
+                sut.giveMeBuilder<RestaurantImageJpaEntity>()
+                    .set(RestaurantImageJpaEntity::id, 0)
+                    .set(RestaurantImageJpaEntity::restaurant, it)
+                    .set(RestaurantImageJpaEntity::isThumbnail, true, 1)
+                    .sampleList(3)
+            }.flatten(),
+        )
 
         test("셀럽이 방문한 음식점을 조회한다.") {
             // when

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -5,17 +5,25 @@ import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.celeb.domain.YoutubeContent
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
 import com.celuveat.restaurant.domain.InterestedRestaurant
+import com.celuveat.restaurant.domain.Restaurant
 import com.celuveat.support.channelIdSpec
 import com.celuveat.support.sut
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.navercorp.fixturemonkey.kotlin.setExp
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
+import io.mockk.Called
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
 
 class RestaurantQueryServiceTest : BehaviorSpec({
     val findRestaurantPort: FindRestaurantPort = mockk()
@@ -71,7 +79,83 @@ class RestaurantQueryServiceTest : BehaviorSpec({
             }
         }
     }
-})
+
+    Given("셀럽이 방문한 음식점을 조회할 때") {
+        val celebrityId = 1L
+        val page = 0
+        val size = 2
+        val visitedRestaurantResult = SliceResult.of(
+            contents = sut.giveMeBuilder<Restaurant>().sampleList(2),
+            currentPage = 0,
+            hasNext = false,
+        )
+        val restaurantIds = visitedRestaurantResult.contents.map { it.id }
+        When("회원이 음식점을 조회하면") {
+            every {
+                findRestaurantPort.findVisitedRestaurantByCelebrity(
+                    celebrityId,
+                    page,
+                    size,
+                )
+            } returns visitedRestaurantResult
+            val memberId = 1L
+            val interestedRestaurants = listOf(
+                sut.giveMeBuilder<InterestedRestaurant>()
+                    .setExp(InterestedRestaurant::restaurant, visitedRestaurantResult.contents[0])
+                    .sample()
+            )
+            every {
+                findInterestedRestaurantPort.findInterestedRestaurantsByIds(
+                    memberId,
+                    restaurantIds
+                )
+            } returns interestedRestaurants
+            val readVisitedRestaurantQuery = ReadVisitedRestaurantQuery(
+                memberId = memberId,
+                celebrityId = celebrityId,
+                page = page,
+                size = size,
+            )
+            val visitedRestaurants = restaurantQueryService.readVisitedRestaurant(readVisitedRestaurantQuery)
+
+            Then("관심 등록 여부가 포함되어 응답한다") {
+                visitedRestaurants.contents.size shouldBe 2
+                visitedRestaurants.contents[0].liked shouldBe true
+            }
+        }
+
+        When("비회원이 음식점을 조회하면") {
+            every {
+                findRestaurantPort.findVisitedRestaurantByCelebrity(
+                    celebrityId,
+                    page,
+                    size,
+                )
+            } returns visitedRestaurantResult
+            val readVisitedRestaurantQuery = ReadVisitedRestaurantQuery(
+                memberId = null,
+                celebrityId = celebrityId,
+                page = page,
+                size = size,
+            )
+            val visitedRestaurants = restaurantQueryService.readVisitedRestaurant(readVisitedRestaurantQuery)
+
+            Then("관심 등록 여부는 false로 응답한다") {
+                visitedRestaurants.contents.size shouldBe 2
+                visitedRestaurants.contents.map { it.liked } shouldBe listOf(false, false)
+                verify { findInterestedRestaurantPort wasNot Called }
+            }
+        }
+    }
+}) {
+    override suspend fun afterEach(
+        testCase: TestCase,
+        result: TestResult,
+    ) {
+        clearAllMocks()
+        unmockkAll()
+    }
+}
 
 private fun generateYoutubeContents(size: Int = 1): List<YoutubeContent> =
     sut.giveMeBuilder<YoutubeContent>().setInner(channelIdSpec).sampleList(size)

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -5,7 +5,7 @@ import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.celeb.domain.YoutubeContent
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.application.port.`in`.query.ReadVisitedRestaurantQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
 import com.celuveat.restaurant.domain.InterestedRestaurant
@@ -30,7 +30,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
     val findCelebritiesPort: FindCelebritiesPort = mockk()
     val findInterestedRestaurantPort: FindInterestedRestaurantPort = mockk()
 
-    val restaurantQueryService = RestaurantQueryService(
+    val restaurantQueryService = RestaurantQueryServiceCelebrity(
         findRestaurantPort,
         findCelebritiesPort,
         findInterestedRestaurantPort,
@@ -110,13 +110,14 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     restaurantIds,
                 )
             } returns interestedRestaurants
-            val readVisitedRestaurantQuery = ReadVisitedRestaurantQuery(
+            val readCelebrityVisitedRestaurantQuery = ReadCelebrityVisitedRestaurantQuery(
                 memberId = memberId,
                 celebrityId = celebrityId,
                 page = page,
                 size = size,
             )
-            val visitedRestaurants = restaurantQueryService.readVisitedRestaurant(readVisitedRestaurantQuery)
+            val visitedRestaurants =
+                restaurantQueryService.readCelebrityVisitedRestaurant(readCelebrityVisitedRestaurantQuery)
 
             Then("관심 등록 여부가 포함되어 응답한다") {
                 visitedRestaurants.contents.size shouldBe 2
@@ -132,13 +133,14 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     size,
                 )
             } returns visitedRestaurantResult
-            val readVisitedRestaurantQuery = ReadVisitedRestaurantQuery(
+            val readCelebrityVisitedRestaurantQuery = ReadCelebrityVisitedRestaurantQuery(
                 memberId = null,
                 celebrityId = celebrityId,
                 page = page,
                 size = size,
             )
-            val visitedRestaurants = restaurantQueryService.readVisitedRestaurant(readVisitedRestaurantQuery)
+            val visitedRestaurants =
+                restaurantQueryService.readCelebrityVisitedRestaurant(readCelebrityVisitedRestaurantQuery)
 
             Then("관심 등록 여부는 false로 응답한다") {
                 visitedRestaurants.contents.size shouldBe 2

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -1,13 +1,13 @@
 package com.celuveat.restaurant.application
 
-import com.celuveat.celeb.application.port.out.FindCelebritiesPort
+import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.celeb.domain.YoutubeContent
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
-import com.celuveat.restaurant.application.port.out.FindRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import com.celuveat.restaurant.domain.InterestedRestaurant
 import com.celuveat.restaurant.domain.Restaurant
 import com.celuveat.support.channelIdSpec
@@ -26,14 +26,14 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 
 class RestaurantQueryServiceTest : BehaviorSpec({
-    val findRestaurantPort: FindRestaurantPort = mockk()
-    val findCelebritiesPort: FindCelebritiesPort = mockk()
-    val findInterestedRestaurantPort: FindInterestedRestaurantPort = mockk()
+    val readRestaurantPort: ReadRestaurantPort = mockk()
+    val readCelebritiesPort: ReadCelebritiesPort = mockk()
+    val readInterestedRestaurantPort: ReadInterestedRestaurantPort = mockk()
 
     val restaurantQueryService = RestaurantQueryServiceCelebrity(
-        findRestaurantPort,
-        findCelebritiesPort,
-        findInterestedRestaurantPort,
+        readRestaurantPort,
+        readCelebritiesPort,
+        readInterestedRestaurantPort,
     )
 
     Given("관심 음식점을 조회할 때") {
@@ -47,13 +47,13 @@ class RestaurantQueryServiceTest : BehaviorSpec({
         )
         val interestedRestaurantResultIds = interestedRestaurantResult.contents.map { it.restaurant.id }
         every {
-            findInterestedRestaurantPort.findInterestedRestaurants(
+            readInterestedRestaurantPort.findInterestedRestaurants(
                 memberId,
                 page,
                 size,
             )
         } returns interestedRestaurantResult
-        every { findCelebritiesPort.findVisitedCelebritiesByRestaurants(interestedRestaurantResultIds) } returns mapOf(
+        every { readCelebritiesPort.findVisitedCelebritiesByRestaurants(interestedRestaurantResultIds) } returns mapOf(
             interestedRestaurantResultIds[0] to sut.giveMeBuilder<Celebrity>()
                 .setExp(Celebrity::youtubeContents, generateYoutubeContents(size = 2))
                 .sampleList(2),
@@ -92,7 +92,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
         val restaurantIds = visitedRestaurantResult.contents.map { it.id }
         When("회원이 음식점을 조회하면") {
             every {
-                findRestaurantPort.findVisitedRestaurantByCelebrity(
+                readRestaurantPort.findVisitedRestaurantByCelebrity(
                     celebrityId,
                     page,
                     size,
@@ -105,7 +105,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     .sample(),
             )
             every {
-                findInterestedRestaurantPort.findInterestedRestaurantsByIds(
+                readInterestedRestaurantPort.findInterestedRestaurantsByIds(
                     memberId,
                     restaurantIds,
                 )
@@ -127,7 +127,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
 
         When("비회원이 음식점을 조회하면") {
             every {
-                findRestaurantPort.findVisitedRestaurantByCelebrity(
+                readRestaurantPort.findVisitedRestaurantByCelebrity(
                     celebrityId,
                     page,
                     size,
@@ -145,7 +145,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
             Then("관심 등록 여부는 false로 응답한다") {
                 visitedRestaurants.contents.size shouldBe 2
                 visitedRestaurants.contents.map { it.liked } shouldBe listOf(false, false)
-                verify { findInterestedRestaurantPort wasNot Called }
+                verify { readInterestedRestaurantPort wasNot Called }
             }
         }
     }

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -4,12 +4,8 @@ import com.celuveat.celeb.application.port.out.FindCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.celeb.domain.YoutubeContent
 import com.celuveat.common.application.port.`in`.result.SliceResult
-import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
-import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
-import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
-import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
 import com.celuveat.support.channelIdSpec
 import com.celuveat.support.sut
@@ -19,20 +15,14 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 
-class RestaurantsServiceTest : BehaviorSpec({
-
+class RestaurantQueryServiceTest : BehaviorSpec({
     val findRestaurantPort: FindRestaurantPort = mockk()
     val findCelebritiesPort: FindCelebritiesPort = mockk()
-    val saveRestaurantPort: SaveRestaurantPort = mockk()
-    val deleteRestaurantPort: DeleteRestaurantPort = mockk()
 
-    val restaurantsService = RestaurantsService(
+    val restaurantQueryService = RestaurantQueryService(
         findRestaurantPort,
         findCelebritiesPort,
-        saveRestaurantPort,
-        deleteRestaurantPort,
     )
 
     Given("관심 음식점을 조회할 때") {
@@ -63,42 +53,12 @@ class RestaurantsServiceTest : BehaviorSpec({
                 page = page,
                 size = size,
             )
-            val interestedRestaurants = restaurantsService.getInterestedRestaurant(getInterestedRestaurantsQuery)
+            val interestedRestaurants = restaurantQueryService.getInterestedRestaurant(getInterestedRestaurantsQuery)
 
             Then("관심 식당 목록을 반환한다") {
                 interestedRestaurants.contents.size shouldBe 3
                 interestedRestaurants.contents[0].visitedCelebrities.size shouldBe 2
                 interestedRestaurants.hasNext shouldBe false
-            }
-        }
-    }
-
-    Given("회원이 관심 음식점 추가 시") {
-        val memberId = 1L
-        val restaurantId = 1L
-
-        When("해당 음식점이") {
-            every { saveRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) } returns Unit
-
-            val command = AddInterestedRestaurantCommand(memberId, restaurantId)
-            restaurantsService.addInterestedRestaurant(command)
-            Then("관심 음식점으로 추가 된다") {
-                verify { saveRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) }
-            }
-        }
-    }
-
-    Given("회원이 관심 음식점 삭제 시") {
-        val memberId = 1L
-        val restaurantId = 1L
-
-        When("해당 음식점이") {
-            every { deleteRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) } returns Unit
-
-            val command = DeleteInterestedRestaurantCommand(memberId, restaurantId)
-            restaurantsService.deleteInterestedRestaurant(command)
-            Then("관심 음식점에서 삭제 된다") {
-                verify { deleteRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) }
             }
         }
     }

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -33,7 +33,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
     val restaurantQueryService = RestaurantQueryService(
         findRestaurantPort,
         findCelebritiesPort,
-        findInterestedRestaurantPort
+        findInterestedRestaurantPort,
     )
 
     Given("관심 음식점을 조회할 때") {
@@ -50,7 +50,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
             findInterestedRestaurantPort.findInterestedRestaurants(
                 memberId,
                 page,
-                size
+                size,
             )
         } returns interestedRestaurantResult
         every { findCelebritiesPort.findVisitedCelebritiesByRestaurants(interestedRestaurantResultIds) } returns mapOf(
@@ -102,12 +102,12 @@ class RestaurantQueryServiceTest : BehaviorSpec({
             val interestedRestaurants = listOf(
                 sut.giveMeBuilder<InterestedRestaurant>()
                     .setExp(InterestedRestaurant::restaurant, visitedRestaurantResult.contents[0])
-                    .sample()
+                    .sample(),
             )
             every {
                 findInterestedRestaurantPort.findInterestedRestaurantsByIds(
                     memberId,
-                    restaurantIds
+                    restaurantIds,
                 )
             } returns interestedRestaurants
             val readVisitedRestaurantQuery = ReadVisitedRestaurantQuery(

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -5,8 +5,9 @@ import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.celeb.domain.YoutubeContent
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.query.GetInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.FindRestaurantPort
-import com.celuveat.restaurant.domain.Restaurant
+import com.celuveat.restaurant.domain.InterestedRestaurant
 import com.celuveat.support.channelIdSpec
 import com.celuveat.support.sut
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
@@ -19,10 +20,12 @@ import io.mockk.mockk
 class RestaurantQueryServiceTest : BehaviorSpec({
     val findRestaurantPort: FindRestaurantPort = mockk()
     val findCelebritiesPort: FindCelebritiesPort = mockk()
+    val findInterestedRestaurantPort: FindInterestedRestaurantPort = mockk()
 
     val restaurantQueryService = RestaurantQueryService(
         findRestaurantPort,
         findCelebritiesPort,
+        findInterestedRestaurantPort
     )
 
     Given("관심 음식점을 조회할 때") {
@@ -30,12 +33,18 @@ class RestaurantQueryServiceTest : BehaviorSpec({
         val page = 0
         val size = 2
         val interestedRestaurantResult = SliceResult.of(
-            contents = sut.giveMeBuilder<Restaurant>().sampleList(3),
+            contents = sut.giveMeBuilder<InterestedRestaurant>().sampleList(3),
             currentPage = 0,
             hasNext = false,
         )
-        val interestedRestaurantResultIds = interestedRestaurantResult.contents.map { it.id }
-        every { findRestaurantPort.findInterestedRestaurants(memberId, page, size) } returns interestedRestaurantResult
+        val interestedRestaurantResultIds = interestedRestaurantResult.contents.map { it.restaurant.id }
+        every {
+            findInterestedRestaurantPort.findInterestedRestaurants(
+                memberId,
+                page,
+                size
+            )
+        } returns interestedRestaurantResult
         every { findCelebritiesPort.findVisitedCelebritiesByRestaurants(interestedRestaurantResultIds) } returns mapOf(
             interestedRestaurantResultIds[0] to sut.giveMeBuilder<Celebrity>()
                 .setExp(Celebrity::youtubeContents, generateYoutubeContents(size = 2))

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
@@ -1,0 +1,50 @@
+package com.celuveat.restaurant.application
+
+import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
+import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
+import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class RestaurantServiceTest : BehaviorSpec({
+    val saveRestaurantPort: SaveRestaurantPort = mockk()
+    val deleteRestaurantPort: DeleteRestaurantPort = mockk()
+
+    val restaurantService = RestaurantService(
+        saveRestaurantPort,
+        deleteRestaurantPort,
+    )
+
+    Given("회원이 관심 음식점 추가 시") {
+        val memberId = 1L
+        val restaurantId = 1L
+
+        When("해당 음식점이") {
+            every { saveRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) } returns Unit
+
+            val command = AddInterestedRestaurantCommand(memberId, restaurantId)
+            restaurantService.addInterestedRestaurant(command)
+            Then("관심 음식점으로 추가 된다") {
+                verify { saveRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) }
+            }
+        }
+    }
+
+    Given("회원이 관심 음식점 삭제 시") {
+        val memberId = 1L
+        val restaurantId = 1L
+
+        When("해당 음식점이") {
+            every { deleteRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) } returns Unit
+
+            val command = DeleteInterestedRestaurantCommand(memberId, restaurantId)
+            restaurantService.deleteInterestedRestaurant(command)
+            Then("관심 음식점에서 삭제 된다") {
+                verify { deleteRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
@@ -3,7 +3,7 @@ package com.celuveat.restaurant.application
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
-import com.celuveat.restaurant.application.port.out.FindInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
 import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
 import io.kotest.assertions.throwables.shouldThrow
@@ -19,12 +19,12 @@ import io.mockk.verify
 class RestaurantServiceTest : BehaviorSpec({
     val saveInterestedRestaurantPort: SaveInterestedRestaurantPort = mockk()
     val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort = mockk()
-    val findInterestedRestaurantPort: FindInterestedRestaurantPort = mockk()
+    val readInterestedRestaurantPort: ReadInterestedRestaurantPort = mockk()
 
     val restaurantService = RestaurantService(
         saveInterestedRestaurantPort,
         deleteInterestedRestaurantPort,
-        findInterestedRestaurantPort,
+        readInterestedRestaurantPort,
     )
 
     Given("회원이 관심 음식점 추가 시") {
@@ -33,7 +33,7 @@ class RestaurantServiceTest : BehaviorSpec({
 
         When("해당 음식점이") {
             every { saveInterestedRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) } returns Unit
-            every { findInterestedRestaurantPort.existsInterestedRestaurant(memberId, restaurantId) } returns false
+            every { readInterestedRestaurantPort.existsInterestedRestaurant(memberId, restaurantId) } returns false
 
             val command = AddInterestedRestaurantCommand(memberId, restaurantId)
             restaurantService.addInterestedRestaurant(command)
@@ -43,7 +43,7 @@ class RestaurantServiceTest : BehaviorSpec({
         }
 
         When("이미 추가된 음식점이면") {
-            every { findInterestedRestaurantPort.existsInterestedRestaurant(memberId, restaurantId) } returns true
+            every { readInterestedRestaurantPort.existsInterestedRestaurant(memberId, restaurantId) } returns true
             val command = AddInterestedRestaurantCommand(memberId, restaurantId)
 
             Then("예외를 발생시킨다") {

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
@@ -2,20 +2,20 @@ package com.celuveat.restaurant.application
 
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
-import com.celuveat.restaurant.application.port.out.DeleteRestaurantPort
-import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
+import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
 class RestaurantServiceTest : BehaviorSpec({
-    val saveRestaurantPort: SaveRestaurantPort = mockk()
-    val deleteRestaurantPort: DeleteRestaurantPort = mockk()
+    val saveInterestedRestaurantPort: SaveInterestedRestaurantPort = mockk()
+    val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort = mockk()
 
     val restaurantService = RestaurantService(
-        saveRestaurantPort,
-        deleteRestaurantPort,
+        saveInterestedRestaurantPort,
+        deleteInterestedRestaurantPort,
     )
 
     Given("회원이 관심 음식점 추가 시") {
@@ -23,12 +23,12 @@ class RestaurantServiceTest : BehaviorSpec({
         val restaurantId = 1L
 
         When("해당 음식점이") {
-            every { saveRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) } returns Unit
+            every { saveInterestedRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) } returns Unit
 
             val command = AddInterestedRestaurantCommand(memberId, restaurantId)
             restaurantService.addInterestedRestaurant(command)
             Then("관심 음식점으로 추가 된다") {
-                verify { saveRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) }
+                verify { saveInterestedRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) }
             }
         }
     }
@@ -38,12 +38,12 @@ class RestaurantServiceTest : BehaviorSpec({
         val restaurantId = 1L
 
         When("해당 음식점이") {
-            every { deleteRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) } returns Unit
+            every { deleteInterestedRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) } returns Unit
 
             val command = DeleteInterestedRestaurantCommand(memberId, restaurantId)
             restaurantService.deleteInterestedRestaurant(command)
             Then("관심 음식점에서 삭제 된다") {
-                verify { deleteRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) }
+                verify { deleteInterestedRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) }
             }
         }
     }

--- a/src/test/kotlin/com/celuveat/support/KotestConfig.kt
+++ b/src/test/kotlin/com/celuveat/support/KotestConfig.kt
@@ -1,0 +1,9 @@
+package com.celuveat.support
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+
+class KotestConfig : AbstractProjectConfig() {
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+}

--- a/src/test/kotlin/com/celuveat/support/KotestConfig.kt
+++ b/src/test/kotlin/com/celuveat/support/KotestConfig.kt
@@ -5,5 +5,5 @@ import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
 
 class KotestConfig : AbstractProjectConfig() {
-    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Test))
 }


### PR DESCRIPTION
# 관련 태스크
- closed #28
---
![Screenshot 2024-08-10 at 00 00 01](https://github.com/user-attachments/assets/c5e798f7-3457-4bb1-9914-4d72257627c4)
Best 셀럽 조회에 대한 API를 개발하였습니다.
제안 드린 것 처럼 셀럽의 음식점 조회는 API를 따로 분리하였습니다! 

작업을 하는 과정에서 몇가지 추가적인 작업이 이루어졌는데요.
1. @DataJpaTest[시 롤백이 되지 않는 오류 해결](https://github.com/2024-celuveat/server/commit/421e9eca6180f3ba0a8d907ffd9e65813d517aff)
Kotest와 DataJpaTest 사용시 예상하는 테스트 라이프 사이클에 따라 @Transactional 롤백이 되지 않는 이슈가 있습니다.
- ref: https://github.com/kotest/kotest/pull/1684
해당 문서 참고하여 전체적으로 적용할 수 있도록 구성하였습니다!!

2. [refactor: 관심 추가한 음식점 (InterestedRestaurant) 도메인으로 분리](https://github.com/2024-celuveat/server/commit/8b9de484e004402ffcaf02d9dc0e976718244917)
#27 리뷰 남겨주신 것처럼 중간테이블 객체도 도메인으로 분리하는 작업을 하였습니다.

3. [refactor: 회원/비회원 인증 처리 AuthContext로 통합](https://github.com/2024-celuveat/server/commit/092399b2231e0a75c0c0556a98d0499caf7ec18e)
셀럽으로 음식점 조회시 회원/비회원도 모두 요청 가능한 API인데요.
회원 전용인 `AuthId`가 아닌, 한번 포장한 객체로 변환하여 전체적으로 적용 하였습니당...!