### PR TITLE
feat: 음식점 검색 api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,19 +29,26 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
+    // DatabaseSource
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-
-    // swagger
+    // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
-    // JJWT
+    // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
+
+    //Kotlin JDSL
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.1")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.1")
+    implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:3.5.1")
+
+    // Test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 
     // Ko-test
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
 
-    //Kotlin JDSL
+    // Kotlin JDSL
     implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.1")
     implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.1")
     implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:3.5.1")

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/KotlinJdslSupport.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/KotlinJdslSupport.kt
@@ -1,0 +1,8 @@
+package com.celuveat.common.adapter.out.persistence
+
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+
+val context = JpqlRenderContext()
+
+val renderer = JpqlRenderer()

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/KotlinJdslSupport.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/KotlinJdslSupport.kt
@@ -1,8 +1,0 @@
-package com.celuveat.common.adapter.out.persistence
-
-import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
-import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
-
-val context = JpqlRenderContext()
-
-val renderer = JpqlRenderer()

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "음식점 API")
 interface RestaurantApi {
@@ -73,4 +74,24 @@ interface RestaurantApi {
     fun readCelebrityRecommendRestaurants(
         @Auth auth: AuthContext,
     ): List<RestaurantPreviewResponse>
+
+    @Operation(summary = "음식점 조건 조회")
+    @GetMapping
+    fun readRestaurants(
+        @Parameter(
+            `in` = ParameterIn.QUERY,
+            description = "지역",
+            example = "성수",
+            required = false,
+        )
+        @RequestParam region: String?,
+        @Parameter(
+            `in` = ParameterIn.QUERY,
+            description = "카테고리",
+            example = "한식",
+            required = false,
+        )
+        @RequestParam category: String?,
+        @PageableDefault(size = 10, page = 0) pageable: Pageable,
+    ): SliceResponse<RestaurantPreviewResponse>
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -78,6 +78,7 @@ interface RestaurantApi {
     @Operation(summary = "음식점 조건 조회")
     @GetMapping
     fun readRestaurants(
+        @Auth auth: AuthContext,
         @Parameter(
             `in` = ParameterIn.QUERY,
             description = "지역",

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -115,7 +115,7 @@ class RestaurantController(
         @Auth auth: AuthContext,
         @RequestParam region: String?,
         @RequestParam category: String?,
-        @PageableDefault pageable: Pageable
+        @PageableDefault pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse> {
         val query = ReadRestaurantsQuery(
             memberId = auth.optionalMemberId(),

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -9,11 +9,13 @@ import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurants
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityRecommendRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadRestaurantsQuery
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/restaurants")
@@ -31,6 +34,7 @@ class RestaurantController(
     private val deleteInterestedRestaurantsUseCase: DeleteInterestedRestaurantsUseCase,
     private val readCelebrityVisitedRestaurantUseCase: ReadCelebrityVisitedRestaurantUseCase,
     private val readCelebrityRecommendRestaurantsUseCase: ReadCelebrityRecommendRestaurantsUseCase,
+    private val readRestaurantsUseCase: ReadRestaurantsUseCase,
 ) : RestaurantApi {
     @GetMapping("/interested")
     override fun getInterestedRestaurants(
@@ -104,5 +108,26 @@ class RestaurantController(
         val query = ReadCelebrityRecommendRestaurantsQuery(memberId = memberId)
         val interestedRestaurant = readCelebrityRecommendRestaurantsUseCase.readCelebrityRecommendRestaurants(query)
         return interestedRestaurant.map(RestaurantPreviewResponse::from)
+    }
+
+    @GetMapping
+    override fun readRestaurants(
+        @Auth auth: AuthContext,
+        @RequestParam region: String?,
+        @RequestParam category: String?,
+        @PageableDefault pageable: Pageable
+    ): SliceResponse<RestaurantPreviewResponse> {
+        val query = ReadRestaurantsQuery(
+            memberId = auth.optionalMemberId(),
+            region = region,
+            category = category,
+            page = pageable.pageNumber,
+            size = pageable.pageSize,
+        )
+        val result = readRestaurantsUseCase.readRestaurants(query)
+        return SliceResponse.from(
+            sliceResult = result,
+            converter = RestaurantPreviewResponse::from,
+        )
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -60,7 +60,7 @@ class RestaurantPersistenceAdapter(
         category: String?,
         region: String?,
         page: Int,
-        size: Int
+        size: Int,
     ): SliceResult<Restaurant> {
         val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
         val filter = RestaurantFilter(category, region)

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -55,6 +55,15 @@ class RestaurantPersistenceAdapter(
         }
     }
 
+    override fun readRestaurantsByCondition(
+        category: String?,
+        region: String?,
+        page: Int,
+        size: Int
+    ): SliceResult<Restaurant> {
+        TODO("Not yet implemented")
+    }
+
     companion object {
         val LATEST_SORTER = Sort.by("createdAt").descending()
     }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package com.celuveat.restaurant.adapter.out.persistence
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantFilter
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
@@ -61,7 +62,22 @@ class RestaurantPersistenceAdapter(
         page: Int,
         size: Int
     ): SliceResult<Restaurant> {
-        TODO("Not yet implemented")
+        val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
+        val filter = RestaurantFilter(category, region)
+        val restaurantSlice = restaurantJpaRepository.findAllByFilter(filter, pageRequest)
+        val restaurants = restaurantSlice.content.map { it }
+        val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurants)
+            .groupBy { it.restaurant.id }
+        return SliceResult.of(
+            contents = restaurantSlice.content.map {
+                restaurantPersistenceMapper.toDomain(
+                    it,
+                    imagesByRestaurants[it.id] ?: emptyList(),
+                )
+            },
+            currentPage = page,
+            hasNext = restaurantSlice.hasNext(),
+        )
     }
 
     companion object {

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
@@ -1,0 +1,16 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface CustomRestaurantRepository {
+    fun findAllByFilter(
+        filter: RestaurantFilter,
+        pageable: Pageable,
+    ): Slice<RestaurantJpaEntity>
+}
+
+data class RestaurantFilter(
+    val category: String?,
+    val region: String?,
+)

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.celuveat.restaurant.adapter.out.persistence.entity
+
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Repository
+
+@Repository
+class CustomRestaurantRepositoryImpl(
+    private val executor: KotlinJdslJpqlExecutor,
+) : CustomRestaurantRepository {
+    override fun findAllByFilter(
+        filter: RestaurantFilter,
+        pageable: Pageable
+    ): Slice<RestaurantJpaEntity> {
+        val findSlice = executor.findSlice(pageable) {
+            select(
+                entity(RestaurantJpaEntity::class),
+            ).from(
+                entity(RestaurantJpaEntity::class),
+            ).whereAnd(
+                filter.category?.let { path(RestaurantJpaEntity::category).eq(it) },
+                filter.region?.let { path(RestaurantJpaEntity::roadAddress).like("%$it%") },
+            )
+        }
+        val restaurants = findSlice.content.filterNotNull()
+        return SliceImpl(
+            restaurants,
+            findSlice.pageable,
+            findSlice.hasNext(),
+        )
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
@@ -12,7 +12,7 @@ class CustomRestaurantRepositoryImpl(
 ) : CustomRestaurantRepository {
     override fun findAllByFilter(
         filter: RestaurantFilter,
-        pageable: Pageable
+        pageable: Pageable,
     ): Slice<RestaurantJpaEntity> {
         val findSlice = executor.findSlice(pageable) {
             select(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
@@ -4,7 +4,7 @@ import com.celuveat.common.utils.findByIdOrThrow
 import com.celuveat.restaurant.exception.NotFoundRestaurantException
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RestaurantJpaRepository : JpaRepository<RestaurantJpaEntity, Long> {
+interface RestaurantJpaRepository : JpaRepository<RestaurantJpaEntity, Long>, CustomRestaurantRepository {
     override fun getById(id: Long): RestaurantJpaEntity {
         return findByIdOrThrow(id) { NotFoundRestaurantException }
     }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -5,9 +5,11 @@ import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityRecommendRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadInterestedRestaurantsQuery
+import com.celuveat.restaurant.application.port.`in`.query.ReadRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
@@ -19,7 +21,10 @@ class RestaurantQueryService(
     private val readRestaurantPort: ReadRestaurantPort,
     private val readCelebritiesPort: ReadCelebritiesPort,
     private val readInterestedRestaurantPort: ReadInterestedRestaurantPort,
-) : ReadInterestedRestaurantsUseCase, ReadCelebrityVisitedRestaurantUseCase, ReadCelebrityRecommendRestaurantsUseCase {
+) : ReadInterestedRestaurantsUseCase,
+    ReadCelebrityVisitedRestaurantUseCase,
+    ReadCelebrityRecommendRestaurantsUseCase,
+    ReadRestaurantsUseCase {
     override fun readInterestedRestaurant(query: ReadInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = readInterestedRestaurantPort.readInterestedRestaurants(
             query.memberId,
@@ -76,5 +81,15 @@ class RestaurantQueryService(
             readInterestedRestaurantPort.readInterestedRestaurantsByIds(it, restaurantIds)
                 .map { interested -> interested.restaurant }.toSet()
         } ?: emptySet()
+    }
+
+    override fun readRestaurants(query: ReadRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
+        val restaurants = readRestaurantPort.readRestaurantsByCondition(
+            category = query.category,
+            region = query.region,
+            page = query.page,
+            size = query.size
+        )
+        TODO()
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -88,7 +88,7 @@ class RestaurantQueryService(
             category = query.category,
             region = query.region,
             page = query.page,
-            size = query.size
+            size = query.size,
         )
         val restaurantIds = restaurants.contents.map { it.id }
         val interestedRestaurants = readInterestedRestaurants(query.memberId, restaurantIds)

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -90,6 +90,15 @@ class RestaurantQueryService(
             page = query.page,
             size = query.size
         )
-        TODO()
+        val restaurantIds = restaurants.contents.map { it.id }
+        val interestedRestaurants = readInterestedRestaurants(query.memberId, restaurantIds)
+        val celebritiesByRestaurants = readCelebritiesPort.readVisitedCelebritiesByRestaurants(restaurantIds)
+        return restaurants.convertContent {
+            RestaurantPreviewResult.of(
+                restaurant = it,
+                liked = interestedRestaurants.contains(it),
+                visitedCelebrities = celebritiesByRestaurants[it.id]!!,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadRestaurantsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadRestaurantsUseCase.kt
@@ -1,0 +1,9 @@
+package com.celuveat.restaurant.application.port.`in`
+
+import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.query.ReadRestaurantsQuery
+import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
+
+interface ReadRestaurantsUseCase {
+    fun readRestaurants(query: ReadRestaurantsQuery): SliceResult<RestaurantPreviewResult>
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
@@ -1,6 +1,6 @@
 package com.celuveat.restaurant.application.port.`in`.query
 
-const val DEFAULT_VISITED_RESTAURANTS_SIZE = 10
+private const val DEFAULT_VISITED_RESTAURANTS_SIZE = 10
 
 data class ReadCelebrityVisitedRestaurantQuery(
     val memberId: Long?,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadInterestedRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadInterestedRestaurantsQuery.kt
@@ -1,6 +1,6 @@
 package com.celuveat.restaurant.application.port.`in`.query
 
-const val DEFAULT_INTERESTED_RESTAURANTS_SIZE = 10
+private const val DEFAULT_INTERESTED_RESTAURANTS_SIZE = 10
 
 data class ReadInterestedRestaurantsQuery(
     val memberId: Long,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
@@ -1,0 +1,10 @@
+package com.celuveat.restaurant.application.port.`in`.query
+
+private const val DEFAULT_RESTAURANTS_SIZE = 10
+
+data class ReadRestaurantsQuery(
+    val category: String?,
+    val region: String?,
+    val page: Int = 0,
+    val size: Int = DEFAULT_RESTAURANTS_SIZE,
+)

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
@@ -3,6 +3,7 @@ package com.celuveat.restaurant.application.port.`in`.query
 private const val DEFAULT_RESTAURANTS_SIZE = 10
 
 data class ReadRestaurantsQuery(
+    val memberId: Long?,
     val category: String?,
     val region: String?,
     val page: Int = 0,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -13,4 +13,11 @@ interface ReadRestaurantPort {
     fun readById(id: Long): Restaurant
 
     fun readCelebrityRecommendRestaurant(): List<Restaurant>
+
+    fun readRestaurantsByCondition(
+        category: String?,
+        region: String?,
+        page: Int,
+        size: Int,
+    ): SliceResult<Restaurant>
 }

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -124,7 +124,7 @@ class RestaurantPersistenceAdapterTest(
             sut.giveMeBuilder<RestaurantJpaEntity>()
                 .setExp(RestaurantJpaEntity::category, "한식", 2)
                 .setExp(RestaurantJpaEntity::roadAddress, "서울", 1)
-                .sampleList(5)
+                .sampleList(5),
         )
 
         // when
@@ -146,7 +146,7 @@ class RestaurantPersistenceAdapterTest(
             sut.giveMeBuilder<RestaurantJpaEntity>()
                 .setExp(RestaurantJpaEntity::category, "한식", 1)
                 .setExp(RestaurantJpaEntity::roadAddress, "서울", 2)
-                .sampleList(4)
+                .sampleList(4),
         )
 
         // when

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -244,7 +244,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
             every {
                 readInterestedRestaurantPort.readInterestedRestaurantsByIds(
                     memberId = memberId,
-                    restaurantIds = restaurantIds
+                    restaurantIds = restaurantIds,
                 )
             } returns interestedRestaurants
 

--- a/src/test/kotlin/com/celuveat/support/PersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/support/PersistenceAdapterTest.kt
@@ -4,6 +4,7 @@ import com.celuveat.auth.adapter.out.TokenAdapter
 import com.celuveat.common.adapter.out.persistence.JpaConfig
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.annotation.Mapper
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.autoconfigure.KotlinJdslAutoConfiguration
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
@@ -17,6 +18,6 @@ import org.springframework.context.annotation.Import
     includeFilters = [ComponentScan.Filter(type = FilterType.ANNOTATION, classes = [Adapter::class, Mapper::class])],
     excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [TokenAdapter::class])],
 )
-@Import(JpaConfig::class)
+@Import(JpaConfig::class, KotlinJdslAutoConfiguration::class)
 @DataJpaTest
 annotation class PersistenceAdapterTest


### PR DESCRIPTION
# 관련 태스크
- closed #39 
---
음식점 조회 API 구현하였습니다!
지역, 카테고리에 따른 동적 쿼리 작성했어요.
JPA에서 Pageable을 통해 만들어주는 쿼리를 활용하고, 동적 쿼리를 작성하기 위해 논의드린 대로 `Kotlin-jdsl`을 도입하였습니다.
Spring data jpa Support 를 사용하기 위해 `com.linecorp.kotlin-jdsl:spring-data-jpa-support`를 추가하였습니다!
ref
- https://kotlin-jdsl.gitbook.io/docs
- https://kotlin-jdsl.gitbook.io/docs/v/ko-1/jpql-with-kotlin-jdsl/spring-supports


추후 위경도 조회 조건이 추가되면 해당 API를 수정해서 활용할 수 있을 것 같아요.