### PR TITLE
fix: 스크롤 조회에 전체 sizecount 응답 추가

### DIFF
--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
@@ -21,6 +21,15 @@ interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJp
 
     @Query(
         """
+        SELECT COUNT(cr)
+        FROM CelebrityRestaurantJpaEntity cr
+        WHERE cr.celebrity.id = :celebrityId
+        """,
+    )
+    fun countRestaurantsByCelebrityId(celebrityId: Long): Long
+
+    @Query(
+        """
         SELECT cr.restaurant
         FROM CelebrityRestaurantJpaEntity cr
         GROUP BY cr.restaurant

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/JdslConfig.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/JdslConfig.kt
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class JdslConfig {
-
     @Bean
     fun jpqlRenderer(): JpqlRenderer {
         return JpqlRenderer()

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/JdslConfig.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/JdslConfig.kt
@@ -1,0 +1,14 @@
+package com.celuveat.common.adapter.out.persistence
+
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JdslConfig {
+
+    @Bean
+    fun jpqlRenderer(): JpqlRenderer {
+        return JpqlRenderer()
+    }
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -105,6 +105,12 @@ interface RestaurantApi {
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse>
 
+    @Operation(summary = "음식점 개수 조회")
+    @GetMapping("/count")
+    fun readAmountOfRestaurants(
+        @ModelAttribute request: ReadRestaurantsRequest,
+    ): Int
+
     @Operation(summary = "이번주 업데이트된 음식점 조회")
     @GetMapping("/weekly")
     fun readWeeklyUpdatedRestaurants(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -71,6 +71,19 @@ interface RestaurantApi {
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse>
 
+    @Operation(summary = "셀럽이 다녀간 음식점 개수 조회")
+    @GetMapping("/celebrity/{celebrityId}/count")
+    fun readAmountOfRestaurantsByCelebrity(
+        @Parameter(
+            `in` = ParameterIn.PATH,
+            description = "셀럽 ID",
+            example = "1",
+            required = true,
+        )
+        @PathVariable celebrityId: Long,
+    ): Int
+
+
     @Operation(summary = "셀럽 추천 음식점 조회")
     @GetMapping("/celebrity/recommend")
     fun readCelebrityRecommendRestaurants(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -30,6 +30,13 @@ interface RestaurantApi {
     ): SliceResponse<RestaurantPreviewResponse>
 
     @SecurityRequirement(name = "JWT")
+    @Operation(summary = "관심 음식점 개수 조회")
+    @GetMapping("/interested/count")
+    fun getAmountOfInterestedRestaurants(
+        @Auth auth: AuthContext,
+    ): Int
+
+    @SecurityRequirement(name = "JWT")
     @Operation(summary = "관심 음식점 추가")
     @PostMapping("/interested/{restaurantId}")
     fun addInterestedRestaurant(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -112,6 +112,12 @@ interface RestaurantApi {
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse>
 
+    @Operation(summary = "이번주 업데이트된 음식점 개수 조회")
+    @GetMapping("/weekly/count")
+    fun readAmountOfWeeklyUpdatedRestaurants(
+        @Auth auth: AuthContext,
+    ): Int
+
     @Operation(summary = "주변 음식점 조회")
     @GetMapping("/nearby/{restaurantId}")
     fun readNearByRestaurants(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -90,7 +90,6 @@ interface RestaurantApi {
         @PathVariable celebrityId: Long,
     ): Int
 
-
     @Operation(summary = "셀럽 추천 음식점 조회")
     @GetMapping("/celebrity/recommend")
     fun readCelebrityRecommendRestaurants(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -3,6 +3,7 @@ package com.celuveat.restaurant.adapter.`in`.rest
 import com.celuveat.auth.adapter.`in`.rest.Auth
 import com.celuveat.auth.adapter.`in`.rest.AuthContext
 import com.celuveat.common.adapter.`in`.rest.response.SliceResponse
+import com.celuveat.common.utils.geometry.SquarePolygon
 import com.celuveat.restaurant.adapter.`in`.rest.request.ReadRestaurantsRequest
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantDetailResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
@@ -10,6 +11,7 @@ import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUse
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
@@ -21,6 +23,7 @@ import com.celuveat.restaurant.application.port.`in`.ReadRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
+import com.celuveat.restaurant.application.port.`in`.query.CountRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityRecommendRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadInterestedRestaurantsQuery
@@ -48,6 +51,7 @@ class RestaurantController(
     private val readCelebrityVisitedRestaurantUseCase: ReadCelebrityVisitedRestaurantUseCase,
     private val readCelebrityRecommendRestaurantsUseCase: ReadCelebrityRecommendRestaurantsUseCase,
     private val readRestaurantsUseCase: ReadRestaurantsUseCase,
+    private val readAmountOfRestaurantsUseCase: ReadAmountOfRestaurantsUseCase,
     private val readWeeklyUpdateRestaurantsUseCase: ReadWeeklyUpdateRestaurantsUseCase,
     private val readAmountOfWeeklyUpdateRestaurantsUseCase: ReadAmountOfWeeklyUpdateRestaurantsUseCase,
     private val readNearbyRestaurantsUseCase: ReadNearbyRestaurantsUseCase,
@@ -158,6 +162,21 @@ class RestaurantController(
             sliceResult = result,
             converter = RestaurantPreviewResponse::from,
         )
+    }
+
+    @GetMapping("/count")
+    override fun readAmountOfRestaurants(@ModelAttribute request: ReadRestaurantsRequest): Int {
+        val query = CountRestaurantsQuery(
+            category = request.category,
+            region = request.region,
+            searchArea = SquarePolygon.ofNullable(
+                lowLongitude = request.lowLongitude,
+                highLongitude = request.highLongitude,
+                lowLatitude = request.lowLatitude,
+                highLatitude = request.highLatitude,
+            ),
+        )
+        return readAmountOfRestaurantsUseCase.readAmountOfRestaurants(query)
     }
 
     @GetMapping("/weekly")

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -8,6 +8,7 @@ import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantDetailRespon
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class RestaurantController(
     private val readInterestedRestaurantsUseCase: ReadInterestedRestaurantsUseCase,
+    private val readAmountOfInterestedRestaurantUseCase: ReadAmountOfInterestedRestaurantUseCase,
     private val addInterestedRestaurantsUseCase: AddInterestedRestaurantsUseCase,
     private val deleteInterestedRestaurantsUseCase: DeleteInterestedRestaurantsUseCase,
     private val readCelebrityVisitedRestaurantUseCase: ReadCelebrityVisitedRestaurantUseCase,
@@ -67,6 +69,12 @@ class RestaurantController(
             sliceResult = interestedRestaurant,
             converter = RestaurantPreviewResponse::from,
         )
+    }
+
+    @GetMapping("/interested/count")
+    override fun getAmountOfInterestedRestaurants(@Auth auth: AuthContext): Int {
+        val memberId = auth.memberId()
+        return readAmountOfInterestedRestaurantUseCase.readAmountOfInterestedRestaurant(memberId)
     }
 
     @PostMapping("/interested/{restaurantId}")

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -10,6 +10,7 @@ import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUse
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
@@ -48,6 +49,7 @@ class RestaurantController(
     private val readCelebrityRecommendRestaurantsUseCase: ReadCelebrityRecommendRestaurantsUseCase,
     private val readRestaurantsUseCase: ReadRestaurantsUseCase,
     private val readWeeklyUpdateRestaurantsUseCase: ReadWeeklyUpdateRestaurantsUseCase,
+    private val readAmountOfWeeklyUpdateRestaurantsUseCase: ReadAmountOfWeeklyUpdateRestaurantsUseCase,
     private val readNearbyRestaurantsUseCase: ReadNearbyRestaurantsUseCase,
     private val readRestaurantDetailUseCase: ReadRestaurantDetailUseCase,
     private val readPopularRestaurantsUseCase: ReadPopularRestaurantsUseCase,
@@ -174,6 +176,10 @@ class RestaurantController(
             sliceResult = result,
             converter = RestaurantPreviewResponse::from,
         )
+    }
+
+    override fun readAmountOfWeeklyUpdatedRestaurants(auth: AuthContext): Int {
+        return readAmountOfWeeklyUpdateRestaurantsUseCase.readAmountOfWeeklyUpdateRestaurants()
     }
 
     @GetMapping("/nearby/{restaurantId}")

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -8,6 +8,7 @@ import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantDetailRespon
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
@@ -48,6 +49,7 @@ class RestaurantController(
     private val readNearbyRestaurantsUseCase: ReadNearbyRestaurantsUseCase,
     private val readRestaurantDetailUseCase: ReadRestaurantDetailUseCase,
     private val readPopularRestaurantsUseCase: ReadPopularRestaurantsUseCase,
+    private val readAmountOfRestaurantByCelebrityUseCase: ReadAmountOfRestaurantByCelebrityUseCase,
 ) : RestaurantApi {
     @GetMapping("/interested")
     override fun getInterestedRestaurants(
@@ -111,6 +113,13 @@ class RestaurantController(
             sliceResult = visitedRestaurant,
             converter = RestaurantPreviewResponse::from,
         )
+    }
+
+    @GetMapping("/celebrity/{celebrityId}/count")
+    override fun readAmountOfRestaurantsByCelebrity(
+        @PathVariable celebrityId: Long,
+    ): Int {
+        return readAmountOfRestaurantByCelebrityUseCase.readAmountOfRestaurantByCelebrity(celebrityId)
     }
 
     @GetMapping("/celebrity/recommend")

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -78,7 +78,9 @@ class RestaurantController(
     }
 
     @GetMapping("/interested/count")
-    override fun getAmountOfInterestedRestaurants(@Auth auth: AuthContext): Int {
+    override fun getAmountOfInterestedRestaurants(
+        @Auth auth: AuthContext,
+    ): Int {
         val memberId = auth.memberId()
         return readAmountOfInterestedRestaurantUseCase.readAmountOfInterestedRestaurant(memberId)
     }
@@ -165,7 +167,9 @@ class RestaurantController(
     }
 
     @GetMapping("/count")
-    override fun readAmountOfRestaurants(@ModelAttribute request: ReadRestaurantsRequest): Int {
+    override fun readAmountOfRestaurants(
+        @ModelAttribute request: ReadRestaurantsRequest,
+    ): Int {
         val query = CountRestaurantsQuery(
             category = request.category,
             region = request.region,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -118,6 +118,13 @@ class RestaurantPersistenceAdapter(
         )
     }
 
+    override fun countByCreatedAtBetween(startOfWeek: LocalDate, endOfWeek: LocalDate): Int {
+        return restaurantJpaRepository.countByCreatedAtBetween(
+            startOfWeek.atStartOfDay(),
+            endOfWeek.atTime(LocalTime.MAX),
+        ).toInt()
+    }
+
     override fun readNearby(id: Long): List<Restaurant> {
         val centralRestaurant = restaurantJpaRepository.getById(id)
         val restaurants = restaurantJpaRepository.findTop5NearestInDistance(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -11,10 +11,10 @@ import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepos
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
-import java.time.LocalDate
-import java.time.LocalTime
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import java.time.LocalDate
+import java.time.LocalTime
 
 @Adapter
 class RestaurantPersistenceAdapter(
@@ -92,7 +92,11 @@ class RestaurantPersistenceAdapter(
         )
     }
 
-    override fun countRestaurantsByCondition(category: String?, region: String?, searchArea: SquarePolygon?): Int {
+    override fun countRestaurantsByCondition(
+        category: String?,
+        region: String?,
+        searchArea: SquarePolygon?,
+    ): Int {
         return restaurantJpaRepository.countAllByFilter(RestaurantFilter(category, region, searchArea)).toInt()
     }
 
@@ -122,7 +126,10 @@ class RestaurantPersistenceAdapter(
         )
     }
 
-    override fun countByCreatedAtBetween(startOfWeek: LocalDate, endOfWeek: LocalDate): Int {
+    override fun countByCreatedAtBetween(
+        startOfWeek: LocalDate,
+        endOfWeek: LocalDate,
+    ): Int {
         return restaurantJpaRepository.countByCreatedAtBetween(
             startOfWeek.atStartOfDay(),
             endOfWeek.atTime(LocalTime.MAX),

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -11,10 +11,10 @@ import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepos
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
 import java.time.LocalDate
 import java.time.LocalTime
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 
 @Adapter
 class RestaurantPersistenceAdapter(
@@ -90,6 +90,10 @@ class RestaurantPersistenceAdapter(
             currentPage = page,
             hasNext = restaurantSlice.hasNext(),
         )
+    }
+
+    override fun countRestaurantsByCondition(category: String?, region: String?, searchArea: SquarePolygon?): Int {
+        return restaurantJpaRepository.countAllByFilter(RestaurantFilter(category, region, searchArea)).toInt()
     }
 
     override fun readByCreatedAtBetween(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -45,6 +45,10 @@ class RestaurantPersistenceAdapter(
         )
     }
 
+    override fun countRestaurantByCelebrity(celebrityId: Long): Int {
+        return celebrityRestaurantJpaRepository.countRestaurantsByCelebrityId(celebrityId).toInt()
+    }
+
     override fun readById(id: Long): Restaurant {
         val restaurant = restaurantJpaRepository.getById(id)
         val images = restaurantImageJpaRepository.findByRestaurant(restaurant)

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
@@ -10,9 +10,7 @@ interface CustomRestaurantRepository {
         pageable: Pageable,
     ): Slice<RestaurantJpaEntity>
 
-    fun countAllByFilter(
-        filter: RestaurantFilter,
-    ): Long
+    fun countAllByFilter(filter: RestaurantFilter): Long
 }
 
 data class RestaurantFilter(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
@@ -9,6 +9,10 @@ interface CustomRestaurantRepository {
         filter: RestaurantFilter,
         pageable: Pageable,
     ): Slice<RestaurantJpaEntity>
+
+    fun countAllByFilter(
+        filter: RestaurantFilter,
+    ): Long
 }
 
 data class RestaurantFilter(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
@@ -1,6 +1,10 @@
 package com.celuveat.restaurant.adapter.out.persistence.entity
 
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import jakarta.persistence.EntityManager
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.domain.SliceImpl
@@ -9,6 +13,9 @@ import org.springframework.stereotype.Repository
 @Repository
 class CustomRestaurantRepositoryImpl(
     private val executor: KotlinJdslJpqlExecutor,
+    private val entityManager: EntityManager,
+    private val context: JpqlRenderContext,
+    private val renderer: JpqlRenderer,
 ) : CustomRestaurantRepository {
     override fun findAllByFilter(
         filter: RestaurantFilter,
@@ -37,5 +44,30 @@ class CustomRestaurantRepositoryImpl(
             findSlice.pageable,
             findSlice.hasNext(),
         )
+    }
+
+    override fun countAllByFilter(filter: RestaurantFilter): Long {
+        val query = jpql {
+            select(
+                count(entity(RestaurantJpaEntity::class)),
+            ).from(
+                entity(RestaurantJpaEntity::class),
+            ).whereAnd(
+                filter.category?.let { path(RestaurantJpaEntity::category).eq(it) },
+                filter.region?.let { path(RestaurantJpaEntity::roadAddress).like("%$it%") },
+                filter.searchArea?.let {
+                    path(RestaurantJpaEntity::longitude).between(
+                        it.lowLongitude,
+                        it.highLongitude
+                    )
+                },
+                filter.searchArea?.let { path(RestaurantJpaEntity::latitude).between(it.lowLatitude, it.highLatitude) },
+            )
+        }
+
+        val rendered = renderer.render(query, context)
+        return entityManager.createQuery(rendered.query, Long::class.java)
+            .apply { rendered.params.forEach { (name, value) -> setParameter(name, value) } }
+            .singleResult
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
@@ -32,7 +32,7 @@ class CustomRestaurantRepositoryImpl(
                 filter.searchArea?.let {
                     path(RestaurantJpaEntity::longitude).between(
                         it.lowLongitude,
-                        it.highLongitude
+                        it.highLongitude,
                     )
                 },
                 filter.searchArea?.let { path(RestaurantJpaEntity::latitude).between(it.lowLatitude, it.highLatitude) },
@@ -58,7 +58,7 @@ class CustomRestaurantRepositoryImpl(
                 filter.searchArea?.let {
                     path(RestaurantJpaEntity::longitude).between(
                         it.lowLongitude,
-                        it.highLongitude
+                        it.highLongitude,
                     )
                 },
                 filter.searchArea?.let { path(RestaurantJpaEntity::latitude).between(it.lowLatitude, it.highLatitude) },

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
@@ -2,11 +2,11 @@ package com.celuveat.restaurant.adapter.out.persistence.entity
 
 import com.celuveat.common.utils.findByIdOrThrow
 import com.celuveat.restaurant.exception.NotFoundRestaurantException
+import java.time.LocalDateTime
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import java.time.LocalDateTime
 
 interface RestaurantJpaRepository : JpaRepository<RestaurantJpaEntity, Long>, CustomRestaurantRepository {
     override fun getById(id: Long): RestaurantJpaEntity {
@@ -19,6 +19,11 @@ interface RestaurantJpaRepository : JpaRepository<RestaurantJpaEntity, Long>, Cu
         endOfWeek: LocalDateTime,
         pageable: Pageable,
     ): Slice<RestaurantJpaEntity>
+
+    fun countByCreatedAtBetween(
+        startOfWeek: LocalDateTime,
+        endOfWeek: LocalDateTime,
+    ): Long
 
     @Query(
         """

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaRepository.kt
@@ -2,11 +2,11 @@ package com.celuveat.restaurant.adapter.out.persistence.entity
 
 import com.celuveat.common.utils.findByIdOrThrow
 import com.celuveat.restaurant.exception.NotFoundRestaurantException
-import java.time.LocalDateTime
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface RestaurantJpaRepository : JpaRepository<RestaurantJpaEntity, Long>, CustomRestaurantRepository {
     override fun getById(id: Long): RestaurantJpaEntity {

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -2,6 +2,7 @@ package com.celuveat.restaurant.application
 
 import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
@@ -38,7 +39,8 @@ class RestaurantQueryService(
     ReadRestaurantDetailUseCase,
     ReadWeeklyUpdateRestaurantsUseCase,
     ReadNearbyRestaurantsUseCase,
-    ReadPopularRestaurantsUseCase {
+    ReadPopularRestaurantsUseCase,
+    ReadAmountOfRestaurantByCelebrityUseCase {
     override fun readInterestedRestaurant(query: ReadInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = readInterestedRestaurantPort.readInterestedRestaurants(
             query.memberId,
@@ -176,5 +178,9 @@ class RestaurantQueryService(
             readInterestedRestaurantPort.readInterestedRestaurantsByIds(it, restaurantIds)
                 .map { interested -> interested.restaurant.id }.toSet()
         } ?: emptySet()
+    }
+
+    override fun readAmountOfRestaurantByCelebrity(celebrityId: Long): Int {
+        return readRestaurantPort.countRestaurantByCelebrity(celebrityId)
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -2,6 +2,7 @@ package com.celuveat.restaurant.application
 
 import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
@@ -33,6 +34,7 @@ class RestaurantQueryService(
     private val readCelebritiesPort: ReadCelebritiesPort,
     private val readInterestedRestaurantPort: ReadInterestedRestaurantPort,
 ) : ReadInterestedRestaurantsUseCase,
+    ReadAmountOfInterestedRestaurantUseCase,
     ReadCelebrityVisitedRestaurantUseCase,
     ReadCelebrityRecommendRestaurantsUseCase,
     ReadRestaurantsUseCase,
@@ -59,6 +61,10 @@ class RestaurantQueryService(
         }
     }
 
+    override fun readAmountOfInterestedRestaurant(memberId: Long): Int {
+        return readInterestedRestaurantPort.countByMemberId(memberId)
+    }
+
     override fun readCelebrityVisitedRestaurant(query: ReadCelebrityVisitedRestaurantQuery): SliceResult<RestaurantPreviewResult> {
         val visitedRestaurants = readRestaurantPort.readVisitedRestaurantByCelebrity(
             query.celebrityId,
@@ -73,6 +79,10 @@ class RestaurantQueryService(
                 liked = interestedRestaurants.contains(it.id),
             )
         }
+    }
+
+    override fun readAmountOfRestaurantByCelebrity(celebrityId: Long): Int {
+        return readRestaurantPort.countRestaurantByCelebrity(celebrityId)
     }
 
     override fun readCelebrityRecommendRestaurants(query: ReadCelebrityRecommendRestaurantsQuery): List<RestaurantPreviewResult> {
@@ -178,9 +188,5 @@ class RestaurantQueryService(
             readInterestedRestaurantPort.readInterestedRestaurantsByIds(it, restaurantIds)
                 .map { interested -> interested.restaurant.id }.toSet()
         } ?: emptySet()
-    }
-
-    override fun readAmountOfRestaurantByCelebrity(celebrityId: Long): Int {
-        return readRestaurantPort.countRestaurantByCelebrity(celebrityId)
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -4,6 +4,7 @@ import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
@@ -13,6 +14,7 @@ import com.celuveat.restaurant.application.port.`in`.ReadPopularRestaurantsUseCa
 import com.celuveat.restaurant.application.port.`in`.ReadRestaurantDetailUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadWeeklyUpdateRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.query.CountRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityRecommendRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadInterestedRestaurantsQuery
@@ -45,7 +47,8 @@ class RestaurantQueryService(
     ReadNearbyRestaurantsUseCase,
     ReadPopularRestaurantsUseCase,
     ReadAmountOfRestaurantByCelebrityUseCase,
-    ReadAmountOfWeeklyUpdateRestaurantsUseCase {
+    ReadAmountOfWeeklyUpdateRestaurantsUseCase,
+    ReadAmountOfRestaurantsUseCase {
     override fun readInterestedRestaurant(query: ReadInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = readInterestedRestaurantPort.readInterestedRestaurants(
             query.memberId,
@@ -120,6 +123,14 @@ class RestaurantQueryService(
                 visitedCelebrities = celebritiesByRestaurants[it.id]!!,
             )
         }
+    }
+
+    override fun readAmountOfRestaurants(query: CountRestaurantsQuery): Int {
+        return readRestaurantPort.countRestaurantsByCondition(
+            category = query.category,
+            region = query.region,
+            searchArea = query.searchArea,
+        )
     }
 
     override fun readWeeklyUpdateRestaurants(query: ReadWeeklyUpdateRestaurantsQuery): SliceResult<RestaurantPreviewResult> {

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -4,6 +4,7 @@ import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
@@ -26,6 +27,7 @@ import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
+import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
 
 @Service
@@ -42,7 +44,8 @@ class RestaurantQueryService(
     ReadWeeklyUpdateRestaurantsUseCase,
     ReadNearbyRestaurantsUseCase,
     ReadPopularRestaurantsUseCase,
-    ReadAmountOfRestaurantByCelebrityUseCase {
+    ReadAmountOfRestaurantByCelebrityUseCase,
+    ReadAmountOfWeeklyUpdateRestaurantsUseCase {
     override fun readInterestedRestaurant(query: ReadInterestedRestaurantsQuery): SliceResult<RestaurantPreviewResult> {
         val interestedRestaurants = readInterestedRestaurantPort.readInterestedRestaurants(
             query.memberId,
@@ -133,6 +136,12 @@ class RestaurantQueryService(
                 visitedCelebrities = celebritiesByRestaurants[it.id]!!,
             )
         }
+    }
+
+    override fun readAmountOfWeeklyUpdateRestaurants(baseDate: LocalDate): Int {
+        val startOfWeek = baseDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val endOfWeek = baseDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+        return readRestaurantPort.countByCreatedAtBetween(startOfWeek = startOfWeek, endOfWeek = endOfWeek)
     }
 
     override fun readNearbyRestaurants(query: ReadNearbyRestaurantsQuery): List<RestaurantPreviewResult> {

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfInterestedRestaurantUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfInterestedRestaurantUseCase.kt
@@ -1,0 +1,5 @@
+package com.celuveat.restaurant.application.port.`in`
+
+interface ReadAmountOfInterestedRestaurantUseCase {
+    fun readAmountOfInterestedRestaurant(memberId: Long): Int
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfRestaurantByCelebrityUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfRestaurantByCelebrityUseCase.kt
@@ -1,0 +1,5 @@
+package com.celuveat.restaurant.application.port.`in`
+
+interface ReadAmountOfRestaurantByCelebrityUseCase {
+    fun readAmountOfRestaurantByCelebrity(celebrityId: Long): Int
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfRestaurantsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfRestaurantsUseCase.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.application.port.`in`
+
+import com.celuveat.restaurant.application.port.`in`.query.CountRestaurantsQuery
+
+interface ReadAmountOfRestaurantsUseCase {
+    fun readAmountOfRestaurants(query: CountRestaurantsQuery): Int
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfWeeklyUpdateRestaurantsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/ReadAmountOfWeeklyUpdateRestaurantsUseCase.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.application.port.`in`
+
+import java.time.LocalDate
+
+interface ReadAmountOfWeeklyUpdateRestaurantsUseCase {
+    fun readAmountOfWeeklyUpdateRestaurants(baseDate: LocalDate = LocalDate.now()): Int
+}

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
@@ -12,3 +12,9 @@ data class ReadRestaurantsQuery(
     val page: Int = 0,
     val size: Int = DEFAULT_RESTAURANTS_SIZE,
 )
+
+data class CountRestaurantsQuery(
+    val category: String?,
+    val region: String?,
+    val searchArea: SquarePolygon?,
+)

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -31,6 +31,11 @@ interface ReadRestaurantPort {
         size: Int,
     ): SliceResult<Restaurant>
 
+    fun countByCreatedAtBetween(
+        startOfWeek: LocalDate,
+        endOfWeek: LocalDate,
+    ): Int
+
     fun readNearby(id: Long): List<Restaurant>
 
     fun readTop10InterestedRestaurantsInDate(

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -24,6 +24,12 @@ interface ReadRestaurantPort {
         size: Int,
     ): SliceResult<Restaurant>
 
+    fun countRestaurantsByCondition(
+        category: String?,
+        region: String?,
+        searchArea: SquarePolygon?,
+    ): Int
+
     fun readByCreatedAtBetween(
         startOfWeek: LocalDate,
         endOfWeek: LocalDate,

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -39,4 +39,6 @@ interface ReadRestaurantPort {
     ): List<Restaurant>
 
     fun readByName(name: String): List<Restaurant>
+
+    fun countRestaurantByCelebrity(celebrityId: Long): Int
 }

--- a/src/main/kotlin/com/celuveat/review/adapter/in/rest/ReviewApi.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/in/rest/ReviewApi.kt
@@ -102,6 +102,18 @@ interface ReviewApi {
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<ReviewPreviewResponse>
 
+    @Operation(summary = "특정 음식점의 리뷰 개수 조회")
+    @GetMapping("/restaurants/{restaurantId}/count")
+    fun readAmountOfRestaurantsReviews(
+        @Parameter(
+            `in` = ParameterIn.PATH,
+            description = "음식점 ID",
+            example = "1",
+            required = true,
+        )
+        @PathVariable restaurantId: Long,
+    ): Int
+
     @Operation(summary = "리뷰 상세조회")
     @GetMapping("/{reviewId}")
     fun readReview(

--- a/src/main/kotlin/com/celuveat/review/adapter/in/rest/ReviewController.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/in/rest/ReviewController.kt
@@ -10,6 +10,7 @@ import com.celuveat.review.adapter.`in`.rest.response.SingleReviewResponse
 import com.celuveat.review.application.port.`in`.ClickHelpfulReviewUseCase
 import com.celuveat.review.application.port.`in`.DeleteHelpfulReviewUseCase
 import com.celuveat.review.application.port.`in`.DeleteReviewUseCase
+import com.celuveat.review.application.port.`in`.ReadAmountOfRestaurantReviewsUseCase
 import com.celuveat.review.application.port.`in`.ReadRestaurantReviewsUseCase
 import com.celuveat.review.application.port.`in`.ReadSingleReviewUseCase
 import com.celuveat.review.application.port.`in`.UpdateReviewUseCase
@@ -36,6 +37,7 @@ class ReviewController(
     private val clickHelpfulReviewUseCase: ClickHelpfulReviewUseCase,
     private val deleteHelpfulReviewUseCase: DeleteHelpfulReviewUseCase,
     private val readRestaurantReviewsUseCase: ReadRestaurantReviewsUseCase,
+    private val readAmountOfRestaurantReviewsUseCase: ReadAmountOfRestaurantReviewsUseCase,
     private val readSingleReviewUseCase: ReadSingleReviewUseCase,
 ) : ReviewApi {
     @PostMapping
@@ -100,6 +102,11 @@ class ReviewController(
             sliceResult = reviews,
             converter = ReviewPreviewResponse::from,
         )
+    }
+
+    @GetMapping("/restaurants/{restaurantId}/count")
+    override fun readAmountOfRestaurantsReviews(@PathVariable restaurantId: Long): Int {
+        return readAmountOfRestaurantReviewsUseCase.readAmountOfRestaurantReviews(restaurantId)
     }
 
     @GetMapping("/{reviewId}")

--- a/src/main/kotlin/com/celuveat/review/adapter/in/rest/ReviewController.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/in/rest/ReviewController.kt
@@ -105,7 +105,9 @@ class ReviewController(
     }
 
     @GetMapping("/restaurants/{restaurantId}/count")
-    override fun readAmountOfRestaurantsReviews(@PathVariable restaurantId: Long): Int {
+    override fun readAmountOfRestaurantsReviews(
+        @PathVariable restaurantId: Long,
+    ): Int {
         return readAmountOfRestaurantReviewsUseCase.readAmountOfRestaurantReviews(restaurantId)
     }
 

--- a/src/main/kotlin/com/celuveat/review/adapter/out/persistence/ReviewPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/out/persistence/ReviewPersistenceAdapter.kt
@@ -66,6 +66,10 @@ class ReviewPersistenceAdapter(
         return reviewJpaRepository.countByWriterId(memberId).toInt()
     }
 
+    override fun countByRestaurantId(restaurantId: Long): Int {
+        return reviewJpaRepository.countByRestaurantId(restaurantId).toInt()
+    }
+
     companion object {
         val LATEST_SORTER = Sort.by("createdAt").descending()
     }

--- a/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/ReviewJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/ReviewJpaRepository.kt
@@ -17,4 +17,6 @@ interface ReviewJpaRepository : JpaRepository<ReviewJpaEntity, Long> {
     ): Slice<ReviewJpaEntity>
 
     fun countByWriterId(writerId: Long): Long
+
+    fun countByRestaurantId(restaurantId: Long): Long
 }

--- a/src/main/kotlin/com/celuveat/review/application/port/ReviewQueryService.kt
+++ b/src/main/kotlin/com/celuveat/review/application/port/ReviewQueryService.kt
@@ -1,6 +1,7 @@
 package com.celuveat.review.application.port
 
 import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.review.application.port.`in`.ReadAmountOfRestaurantReviewsUseCase
 import com.celuveat.review.application.port.`in`.ReadRestaurantReviewsUseCase
 import com.celuveat.review.application.port.`in`.ReadSingleReviewUseCase
 import com.celuveat.review.application.port.`in`.result.ReviewPreviewResult
@@ -15,7 +16,7 @@ class ReviewQueryService(
     private val readReviewPort: ReadReviewPort,
     private val readHelpfulReviewPort: ReadHelpfulReviewPort,
     private val saveReviewPort: SaveReviewPort,
-) : ReadRestaurantReviewsUseCase, ReadSingleReviewUseCase {
+) : ReadRestaurantReviewsUseCase, ReadSingleReviewUseCase, ReadAmountOfRestaurantReviewsUseCase {
     override fun readAll(
         memberId: Long?,
         restaurantId: Long,
@@ -28,6 +29,10 @@ class ReviewQueryService(
                 .map { helpful -> helpful.review }.toSet()
         } ?: emptySet()
         return reviewResults.convertContent { ReviewPreviewResult.of(it, reviewHelpfulReviewMapping.contains(it)) }
+    }
+
+    override fun readAmountOfRestaurantReviews(restaurantId: Long): Int {
+        return readReviewPort.countByRestaurantId(restaurantId)
     }
 
     override fun read(

--- a/src/main/kotlin/com/celuveat/review/application/port/in/ReadAmountOfRestaurantReviewsUseCase.kt
+++ b/src/main/kotlin/com/celuveat/review/application/port/in/ReadAmountOfRestaurantReviewsUseCase.kt
@@ -1,0 +1,5 @@
+package com.celuveat.review.application.port.`in`
+
+interface ReadAmountOfRestaurantReviewsUseCase {
+    fun readAmountOfRestaurantReviews(restaurantId: Long): Int
+}

--- a/src/main/kotlin/com/celuveat/review/application/port/out/ReadReviewPort.kt
+++ b/src/main/kotlin/com/celuveat/review/application/port/out/ReadReviewPort.kt
@@ -13,4 +13,6 @@ interface ReadReviewPort {
     ): SliceResult<Review>
 
     fun countByWriterId(memberId: Long): Int
+
+    fun countByRestaurantId(restaurantId: Long): Int
 }

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -10,6 +10,7 @@ import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUse
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
@@ -65,6 +66,7 @@ class RestaurantControllerTest(
     @MockkBean val readAmountOfInterestedRestaurantUseCase: ReadAmountOfInterestedRestaurantUseCase,
     @MockkBean val readAmountOfRestaurantByCelebrityUseCase: ReadAmountOfRestaurantByCelebrityUseCase,
     @MockkBean val readAmountOfWeeklyUpdateRestaurantsUseCase: ReadAmountOfWeeklyUpdateRestaurantsUseCase,
+    @MockkBean val readAmountOfRestaurantsUseCase: ReadAmountOfRestaurantsUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -8,6 +8,8 @@ import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantDetailRespon
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
@@ -59,6 +61,8 @@ class RestaurantControllerTest(
     @MockkBean val readNearbyRestaurantsUseCase: ReadNearbyRestaurantsUseCase,
     @MockkBean val readRestaurantDetailUseCase: ReadRestaurantDetailUseCase,
     @MockkBean val readPopularRestaurantsUseCase: ReadPopularRestaurantsUseCase,
+    @MockkBean val readAmountOfInterestedRestaurantUseCase: ReadAmountOfInterestedRestaurantUseCase,
+    @MockkBean val readAmountOfRestaurantByCelebrityUseCase: ReadAmountOfRestaurantByCelebrityUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -10,6 +10,7 @@ import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUse
 import com.celuveat.restaurant.application.port.`in`.DeleteInterestedRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfInterestedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadAmountOfRestaurantByCelebrityUseCase
+import com.celuveat.restaurant.application.port.`in`.ReadAmountOfWeeklyUpdateRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityRecommendRestaurantsUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadCelebrityVisitedRestaurantUseCase
 import com.celuveat.restaurant.application.port.`in`.ReadInterestedRestaurantsUseCase
@@ -63,6 +64,7 @@ class RestaurantControllerTest(
     @MockkBean val readPopularRestaurantsUseCase: ReadPopularRestaurantsUseCase,
     @MockkBean val readAmountOfInterestedRestaurantUseCase: ReadAmountOfInterestedRestaurantUseCase,
     @MockkBean val readAmountOfRestaurantByCelebrityUseCase: ReadAmountOfRestaurantByCelebrityUseCase,
+    @MockkBean val readAmountOfWeeklyUpdateRestaurantsUseCase: ReadAmountOfWeeklyUpdateRestaurantsUseCase,
     // for AuthMemberArgumentResolver
     @MockkBean val extractMemberIdUseCase: ExtractMemberIdUseCase,
 ) : FunSpec({

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -176,6 +176,26 @@ class RestaurantPersistenceAdapterTest(
         restaurants.hasNext shouldBe false
     }
 
+    test("조건에 맞는 음식점의 개수를 조회 한다.") {
+        // given
+        restaurantJpaRepository.saveAll(
+            sut.giveMeBuilder<RestaurantJpaEntity>()
+                .setExp(RestaurantJpaEntity::category, "한식", 2)
+                .setExp(RestaurantJpaEntity::roadAddress, "서울", 1)
+                .sampleList(5),
+        )
+
+        // when
+        val count = restaurantPersistenceAdapter.countRestaurantsByCondition(
+            category = "한식",
+            region = "서울",
+            searchArea = null,
+        )
+
+        // then
+        count shouldBe 1
+    }
+
     test("최근 업데이트된 음식점을 조회한다.") {
         // given
         val savedRestaurants = restaurantJpaRepository.saveAll(

--- a/src/test/kotlin/com/celuveat/support/PersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/support/PersistenceAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.celuveat.support
 
 import com.celuveat.auth.adapter.out.TokenAdapter
+import com.celuveat.common.adapter.out.persistence.JdslConfig
 import com.celuveat.common.adapter.out.persistence.JpaConfig
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.annotation.Mapper
@@ -18,6 +19,6 @@ import org.springframework.context.annotation.Import
     includeFilters = [ComponentScan.Filter(type = FilterType.ANNOTATION, classes = [Adapter::class, Mapper::class])],
     excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [TokenAdapter::class])],
 )
-@Import(JpaConfig::class, KotlinJdslAutoConfiguration::class)
+@Import(JpaConfig::class, KotlinJdslAutoConfiguration::class, JdslConfig::class)
 @DataJpaTest
 annotation class PersistenceAdapterTest


### PR DESCRIPTION
# 관련 태스크
- closed #64 
---
논의했던 내용처럼 스크롤(페이징) 조회에 대해 전체 데이터 크기를 응답하는 API 를 추가하였습니다.

추가된 API
- [x] 셀럽 페이지내 음식점
- [x] 관심 음식점 API
- [x] 이번주 업데이트 된 음식점 조회
- [x] 음식점 조건 조회
- [x] 리뷰 조회 