### PR TITLE
fix: 회원 탈퇴 플로우 수정

### DIFF
--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/DummyEntityInitializer.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/DummyEntityInitializer.kt
@@ -64,6 +64,7 @@ class DummyEntityInitializer(
             email = "email@celuveat.com",
             socialId = "1234567890",
             serverType = SocialLoginType.KAKAO,
+            refreshToken = "refresh"
         )
         return memberJpaRepository.save(member)
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginApi.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginApi.kt
@@ -63,7 +63,7 @@ interface SocialLoginApi {
 
     @SecurityRequirement(name = "JWT")
     @Operation(summary = "소셜 회원 탈퇴")
-    @DeleteMapping("/withdraw/{socialLoginType}")
+    @DeleteMapping("/withdraw")
     fun withdraw(
         @Auth auth: AuthContext,
         @Parameter(
@@ -71,13 +71,6 @@ interface SocialLoginApi {
             required = true,
             description = "소셜 로그인 서비스에서 제공해주는 auth code",
         )
-        @RequestParam authCode: String,
-        @Parameter(
-            `in` = ParameterIn.PATH,
-            required = true,
-            description = "소셜 로그인 타입",
-        )
-        @PathVariable socialLoginType: SocialLoginType,
         @Parameter(
             `in` = ParameterIn.HEADER,
             required = true,

--- a/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/in/rest/SocialLoginController.kt
@@ -49,15 +49,13 @@ class SocialLoginController(
         return socialLoginUrl
     }
 
-    @DeleteMapping("/withdraw/{socialLoginType}")
+    @DeleteMapping("/withdraw")
     override fun withdraw(
         @Auth auth: AuthContext,
-        @RequestParam authCode: String,
-        @PathVariable socialLoginType: SocialLoginType,
         @RequestHeader(HttpHeaders.ORIGIN) requestOrigin: String,
     ): ResponseEntity<Unit> {
         val memberId = auth.memberId()
-        val command = WithdrawSocialLoginCommand(memberId, authCode, socialLoginType, requestOrigin)
+        val command = WithdrawSocialLoginCommand(memberId, requestOrigin)
         withdrawSocialLoginUseCase.withdraw(command)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/FetchSocialMemberAdapter.kt
@@ -35,11 +35,11 @@ class FetchSocialMemberAdapter(
     }
 
     override fun withdraw(
-        authCode: String,
+        refreshToken: String,
         socialLoginType: SocialLoginType,
         requestOrigin: String,
     ) {
         val socialLoginClient = getSocialLoginClient(socialLoginType)
-        socialLoginClient.withdraw(authCode, requestOrigin)
+        socialLoginClient.withdraw(refreshToken, requestOrigin)
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/SocialLoginClient.kt
@@ -14,7 +14,7 @@ interface SocialLoginClient {
     fun getSocialLoginUrl(requestOrigin: String): String
 
     fun withdraw(
-        authCode: String,
+        refreshToken: String,
         requestOrigin: String,
     )
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleApiClient.kt
@@ -19,6 +19,12 @@ interface GoogleApiClient {
         @RequestHeader(AUTHORIZATION) bearerToken: String,
     ): GoogleMemberInfoResponse
 
+    // ref - https://cloud.google.com/apigee/docs/api-platform/security/oauth/access-tokens?hl=ko#refreshinganaccesstoken
+    @PostExchange(url = "https://oauth2.googleapis.com/token")
+    fun refreshToken(
+        @RequestParam params: Map<String, String>,
+    ): GoogleSocialLoginToken
+
     // ref - https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke
     @PostExchange("https://oauth2.googleapis.com/revoke")
     fun withdraw(

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -27,7 +27,8 @@ class GoogleSocialLoginClient(
         val redirectUrl = toRedirectUrl(requestOrigin)
         validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
-        return fetchMemberInfo(socialLoginToken.accessToken).toMember()
+        return fetchMemberInfo(socialLoginToken.accessToken)
+            .toMember(socialLoginToken.refreshToken)
     }
 
     private fun validateAllowedRedirectUrl(redirectUrl: String) {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/GoogleSocialLoginClient.kt
@@ -65,13 +65,25 @@ class GoogleSocialLoginClient(
             .toUriString()
     }
 
+    private fun toRedirectUrl(requestOrigin: String) = "$requestOrigin/oauth/google"
+
     override fun withdraw(
-        authCode: String,
+        refreshToken: String,
         requestOrigin: String,
     ) {
-        val socialLoginToken = fetchAccessToken(authCode, toRedirectUrl(requestOrigin))
+        val socialLoginToken = refreshToken(refreshToken)
         googleApiClient.withdraw(socialLoginToken.accessToken)
     }
 
-    private fun toRedirectUrl(requestOrigin: String) = "$requestOrigin/oauth/google"
+    private fun refreshToken(
+        refreshToken: String,
+    ): GoogleSocialLoginToken {
+        val tokenRequestBody = mapOf(
+            "grant_type" to "refresh_token",
+            "client_id" to googleSocialLoginProperty.clientId,
+            "client_secret" to googleSocialLoginProperty.clientSecret,
+            "refresh_token" to refreshToken,
+        )
+        return googleApiClient.refreshToken(tokenRequestBody)
+    }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/response/GoogleMemberInfoResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/google/response/GoogleMemberInfoResponse.kt
@@ -15,7 +15,7 @@ data class GoogleMemberInfoResponse(
     private val picture: String,
     private val email: String,
 ) {
-    fun toMember(): Member {
+    fun toMember(refreshToken: String): Member {
         return Member(
             nickname = name,
             profileImageUrl = picture,
@@ -23,6 +23,7 @@ data class GoogleMemberInfoResponse(
             socialIdentifier = SocialIdentifier(
                 serverType = SocialLoginType.GOOGLE,
                 socialId = id,
+                refreshToken = refreshToken,
             ),
         )
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoApiClient.kt
@@ -22,6 +22,12 @@ interface KakaoApiClient {
         @RequestHeader(name = AUTHORIZATION) bearerToken: String,
     ): KakaoMemberInfoResponse
 
+    // ref - https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#refresh-token
+    @PostExchange(url = "https://kauth.kakao.com/oauth/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+    fun refreshToken(
+        @RequestParam body: Map<String, String>,
+    ): KakaoSocialLoginToken
+
     // ref - https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink
     @PostExchange(url = "https://kapi.kakao.com/v1/user/unlink", contentType = APPLICATION_FORM_URLENCODED_VALUE)
     fun withdraw(

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -27,7 +27,8 @@ class KakaoSocialLoginClient(
         val redirectUrl = toRedirectUrl(requestOrigin)
         validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode, redirectUrl)
-        return fetchMemberInfo(socialLoginToken.accessToken).toMember()
+        return fetchMemberInfo(socialLoginToken.accessToken)
+            .toMember(socialLoginToken.refreshToken)
     }
 
     private fun validateAllowedRedirectUrl(redirectUrl: String) {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/KakaoSocialLoginClient.kt
@@ -65,13 +65,25 @@ class KakaoSocialLoginClient(
             .toUriString()
     }
 
+    private fun toRedirectUrl(requestOrigin: String) = "$requestOrigin/oauth/kakao"
+
     override fun withdraw(
-        authCode: String,
+        refreshToken: String,
         requestOrigin: String,
     ) {
-        val socialLoginToken = fetchAccessToken(authCode, toRedirectUrl(requestOrigin))
+        val socialLoginToken = refreshToken(refreshToken)
         kakaoApiClient.withdraw("Bearer ${socialLoginToken.accessToken}")
     }
 
-    private fun toRedirectUrl(requestOrigin: String) = "$requestOrigin/oauth/kakao"
+    private fun refreshToken(
+        refreshToken: String,
+    ): KakaoSocialLoginToken {
+        val tokenRequestBody = mapOf(
+            "grant_type" to "refresh_token",
+            "client_id" to kakaoSocialLoginProperty.clientId,
+            "refresh_token" to refreshToken,
+            "client_secret" to kakaoSocialLoginProperty.clientSecret,
+        )
+        return kakaoApiClient.refreshToken(tokenRequestBody)
+    }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/response/KakaoMemberInfoResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/kakao/response/KakaoMemberInfoResponse.kt
@@ -11,7 +11,7 @@ data class KakaoMemberInfoResponse(
     private val id: String,
     private val kakaoAccount: KakaoAccount,
 ) {
-    fun toMember(): Member {
+    fun toMember(refreshToken: String): Member {
         return Member(
             nickname = kakaoAccount.profile.nickname,
             profileImageUrl = kakaoAccount.profile.profileImageUrl,
@@ -19,6 +19,7 @@ data class KakaoMemberInfoResponse(
             socialIdentifier = SocialIdentifier(
                 serverType = SocialLoginType.KAKAO,
                 socialId = id,
+                refreshToken = refreshToken,
             ),
         )
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverApiClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverApiClient.kt
@@ -15,6 +15,12 @@ interface NaverApiClient {
         @RequestParam params: Map<String, String>,
     ): NaverSocialLoginToken
 
+    // ref - https://developers.naver.com/docs/login/api/api.md
+    @PostExchange(url = "https://nid.naver.com/oauth2.0/token")
+    fun refreshToken(
+        @RequestParam params: Map<String, String>,
+    ): NaverSocialLoginToken
+
     // ref - https://developers.naver.com/docs/login/profile/profile.md
     @GetExchange("https://openapi.naver.com/v1/nid/me")
     fun fetchMemberInfo(

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -27,7 +27,8 @@ class NaverSocialLoginClient(
         val redirectUrl = toRedirectUrl(requestOrigin)
         validateAllowedRedirectUrl(redirectUrl)
         val socialLoginToken = fetchAccessToken(authCode)
-        return fetchMemberInfo(socialLoginToken.accessToken).toMember()
+        return fetchMemberInfo(socialLoginToken.accessToken)
+            .toMember(socialLoginToken.refreshToken)
     }
 
     private fun validateAllowedRedirectUrl(redirectUrl: String) {

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/NaverSocialLoginClient.kt
@@ -63,17 +63,27 @@ class NaverSocialLoginClient(
     }
 
     override fun withdraw(
-        authCode: String,
+        refreshToken: String,
         requestOrigin: String,
     ) {
-        val accessToken = fetchAccessToken(authCode)
-        val tokenRequestBody = mapOf(
+        val accessToken = refreshToken(refreshToken)
+        val withdrawRequestBody = mapOf(
             "client_id" to naverSocialLoginProperty.clientId,
             "client_secret" to naverSocialLoginProperty.clientSecret,
             "access_token" to accessToken.accessToken,
             "grant_type" to "delete",
         )
-        naverApiClient.withdraw(tokenRequestBody)
+        naverApiClient.withdraw(withdrawRequestBody)
+    }
+
+    private fun refreshToken(refreshToken: String): NaverSocialLoginToken {
+        val tokenRequestBody = mapOf(
+            "grant_type" to "refresh_token",
+            "client_id" to naverSocialLoginProperty.clientId,
+            "client_secret" to naverSocialLoginProperty.clientSecret,
+            "refresh_token" to refreshToken,
+        )
+        return naverApiClient.refreshToken(tokenRequestBody)
     }
 
     private fun toRedirectUrl(requestOrigin: String) = "$requestOrigin/oauth/naver"

--- a/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/response/NaverMemberInfoResponse.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/oauth/naver/response/NaverMemberInfoResponse.kt
@@ -12,7 +12,7 @@ data class NaverMemberInfoResponse(
     private val message: String,
     private val response: Response,
 ) {
-    fun toMember(): Member {
+    fun toMember(refreshToken: String): Member {
         return Member(
             nickname = response.nickname,
             profileImageUrl = response.profileImage,
@@ -20,6 +20,7 @@ data class NaverMemberInfoResponse(
             socialIdentifier = SocialIdentifier(
                 serverType = SocialLoginType.NAVER,
                 socialId = response.id,
+                refreshToken = refreshToken,
             ),
         )
     }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaEntity.kt
@@ -21,6 +21,7 @@ class MemberJpaEntity(
     @Enumerated(EnumType.STRING)
     val serverType: SocialLoginType,
     val socialId: String,
+    var refreshToken: String
 ) : RootEntity<Long>() {
     override fun id(): Long {
         return this.id

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberPersistenceMapper.kt
@@ -14,6 +14,7 @@ class MemberPersistenceMapper {
             email = member.email,
             serverType = member.socialIdentifier.serverType,
             socialId = member.socialIdentifier.socialId,
+            refreshToken = member.socialIdentifier.refreshToken,
         )
     }
 
@@ -26,6 +27,7 @@ class MemberPersistenceMapper {
             socialIdentifier = SocialIdentifier(
                 serverType = entity.serverType,
                 socialId = entity.socialId,
+                refreshToken = entity.refreshToken,
             ),
         )
     }

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -44,9 +44,10 @@ class SocialLoginService(
     }
 
     override fun withdraw(command: WithdrawSocialLoginCommand) {
+        val member = readMemberPort.readById(command.memberId)
         withdrawSocialMemberPort.withdraw(
-            command.authCode,
-            command.socialLoginType,
+            member.socialIdentifier.refreshToken,
+            member.socialIdentifier.serverType,
             command.requestOrigin,
         )
         deleteMemberPort.deleteById(command.memberId)

--- a/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
+++ b/src/main/kotlin/com/celuveat/member/application/SocialLoginService.kt
@@ -31,6 +31,8 @@ class SocialLoginService(
         )
         val signInMember = readMemberPort.findBySocialIdentifier(member.socialIdentifier)
             ?: saveMemberPort.save(member)
+        signInMember.updateRefreshToken(member.socialIdentifier.refreshToken)
+        saveMemberPort.save(member)
         return signInMember.id
     }
 

--- a/src/main/kotlin/com/celuveat/member/application/port/in/command/WithdrawSocialLoginCommand.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/in/command/WithdrawSocialLoginCommand.kt
@@ -1,10 +1,6 @@
 package com.celuveat.member.application.port.`in`.command
 
-import com.celuveat.member.domain.SocialLoginType
-
 data class WithdrawSocialLoginCommand(
     val memberId: Long,
-    val authCode: String,
-    val socialLoginType: SocialLoginType,
     val requestOrigin: String,
 )

--- a/src/main/kotlin/com/celuveat/member/application/port/out/WithdrawSocialMemberPort.kt
+++ b/src/main/kotlin/com/celuveat/member/application/port/out/WithdrawSocialMemberPort.kt
@@ -4,7 +4,7 @@ import com.celuveat.member.domain.SocialLoginType
 
 interface WithdrawSocialMemberPort {
     fun withdraw(
-        authCode: String,
+        refreshToken: String,
         socialLoginType: SocialLoginType,
         requestOrigin: String,
     )

--- a/src/main/kotlin/com/celuveat/member/domain/Member.kt
+++ b/src/main/kotlin/com/celuveat/member/domain/Member.kt
@@ -23,6 +23,10 @@ class Member(
         this.profileImageUrl = profileImageUrl
     }
 
+    fun updateRefreshToken(refreshToken: String) {
+        socialIdentifier.refreshToken = refreshToken
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/com/celuveat/member/domain/SocialIdentifier.kt
+++ b/src/main/kotlin/com/celuveat/member/domain/SocialIdentifier.kt
@@ -3,4 +3,5 @@ package com.celuveat.member.domain
 data class SocialIdentifier(
     val serverType: SocialLoginType,
     val socialId: String,
+    var refreshToken: String,
 )


### PR DESCRIPTION
### 이슈 
- #67 

### 논의 사항
- 카카오 같은 경우 refresh token 의 만료 기한이 있는데, 만약 회원 탈퇴 시 해당 refresh token 이 만료되었다면 다시 로그인하는 과정이 필요해짐.
따라서 그냥 하루에 1번씩 refresh token 업데이트 시켜주는 스케줄러를 사용해 보는 건 어떨지?

### 참고 사항
- 구글 로그인 뭔가 명확해 보이지는 않아서 오류가 있을수도 있습니다.