### PR TITLE
feat: 음식점 조회 시 셀럽 필터 추가

### DIFF
--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityApi.kt
@@ -5,6 +5,8 @@ import com.celuveat.auth.adapter.`in`.rest.AuthContext
 import com.celuveat.celeb.adapter.`in`.rest.response.BestCelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityWithInterestedResponse
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadRestaurantsRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 
@@ -70,4 +73,10 @@ interface CelebrityApi {
         )
         @PathVariable celebrityId: Long,
     ): CelebrityWithInterestedResponse
+
+    @Operation(summary = "필터용 셀럽 조회")
+    @GetMapping("/in/restaurants/condition")
+    fun readCelebritiesInRestaurantsCondition(
+        @ModelAttribute request: ReadRestaurantsRequest,
+    ): List<SimpleCelebrityResponse>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
@@ -100,7 +100,7 @@ class CelebrityController(
             ),
         )
 
-        val results = readCelebritiesInRestaurantConditionUseCase.readCelebrities(query)
+        val results = readCelebritiesInRestaurantConditionUseCase.readCelebritiesInRestaurantCondition(query)
         return results.map { SimpleCelebrityResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/in/rest/CelebrityController.kt
@@ -5,16 +5,22 @@ import com.celuveat.auth.adapter.`in`.rest.AuthContext
 import com.celuveat.celeb.adapter.`in`.rest.response.BestCelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityResponse
 import com.celuveat.celeb.adapter.`in`.rest.response.CelebrityWithInterestedResponse
+import com.celuveat.celeb.adapter.`in`.rest.response.SimpleCelebrityResponse
 import com.celuveat.celeb.application.port.`in`.AddInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.DeleteInterestedCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadCelebritiesInRestaurantConditionUseCase
 import com.celuveat.celeb.application.port.`in`.ReadCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.ReadInterestedCelebritiesUseCase
 import com.celuveat.celeb.application.port.`in`.command.AddInterestedCelebrityCommand
 import com.celuveat.celeb.application.port.`in`.command.DeleteInterestedCelebrityCommand
+import com.celuveat.celeb.application.port.`in`.query.ReadCelebritiesInRestaurantConditionQuery
 import com.celuveat.celeb.application.port.`in`.query.ReadCelebrityQuery
+import com.celuveat.common.utils.geometry.SquarePolygon
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadRestaurantsRequest
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -28,6 +34,7 @@ class CelebrityController(
     private val addInterestedCelebrityUseCase: AddInterestedCelebrityUseCase,
     private val deleteInterestedCelebrityUseCase: DeleteInterestedCelebrityUseCase,
     private val readCelebrityUseCase: ReadCelebrityUseCase,
+    private val readCelebritiesInRestaurantConditionUseCase: ReadCelebritiesInRestaurantConditionUseCase,
 ) : CelebrityApi {
     @GetMapping("/interested")
     override fun readInterestedCelebrities(
@@ -76,5 +83,24 @@ class CelebrityController(
         val query = ReadCelebrityQuery(memberId, celebrityId)
         val celebrityResult = readCelebrityUseCase.readCelebrity(query)
         return CelebrityWithInterestedResponse.from(celebrityResult)
+    }
+
+    @GetMapping("/in/restaurants/condition")
+    override fun readCelebritiesInRestaurantsCondition(
+        @ModelAttribute request: ReadRestaurantsRequest,
+    ): List<SimpleCelebrityResponse> {
+        val query = ReadCelebritiesInRestaurantConditionQuery(
+            category = request.category,
+            region = request.region,
+            searchArea = SquarePolygon.ofNullable(
+                lowLongitude = request.lowLongitude,
+                highLongitude = request.highLongitude,
+                lowLatitude = request.lowLatitude,
+                highLatitude = request.highLatitude,
+            ),
+        )
+
+        val results = readCelebritiesInRestaurantConditionUseCase.readCelebrities(query)
+        return results.map { SimpleCelebrityResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -33,7 +33,7 @@ class CelebrityPersistenceAdapter(
             }
     }
 
-    override fun readCelebritiesByRestaurants(restaurantIds: List<Long>): List<Celebrity> {
+    override fun readByRestaurants(restaurantIds: List<Long>): List<Celebrity> {
         return celebrityRestaurantJpaRepository.findAllByRestaurantIdIn(restaurantIds)
             .map { it.celebrity }
             .distinct()

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapter.kt
@@ -2,6 +2,7 @@ package com.celuveat.celeb.adapter.out.persistence
 
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityPersistenceMapper
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityYoutubeContentJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.YoutubeContentJpaEntity
@@ -14,6 +15,7 @@ class CelebrityPersistenceAdapter(
     private val celebrityJpaRepository: CelebrityJpaRepository,
     private val celebrityYoutubeContentJpaRepository: CelebrityYoutubeContentJpaRepository,
     private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
+    private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
     private val celebrityPersistenceMapper: CelebrityPersistenceMapper,
 ) : ReadCelebritiesPort {
     override fun readVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>> {
@@ -29,6 +31,13 @@ class CelebrityPersistenceAdapter(
                     )
                 }
             }
+    }
+
+    override fun readCelebritiesByRestaurants(restaurantIds: List<Long>): List<Celebrity> {
+        return celebrityRestaurantJpaRepository.findAllByRestaurantIdIn(restaurantIds)
+            .map { it.celebrity }
+            .distinct()
+            .map { celebrityPersistenceMapper.toDomainWithoutYoutubeContent(it) }
     }
 
     private fun celebritiesToContentMap(celebrityIds: List<Long>): Map<Long, List<YoutubeContentJpaEntity>> =

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityJpaEntity.kt
@@ -16,7 +16,7 @@ class CelebrityJpaEntity(
     val profileImageUrl: String,
     val introduction: String,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaEntity.kt
@@ -25,7 +25,7 @@ class CelebrityRestaurantJpaEntity(
     @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val restaurant: RestaurantJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
@@ -3,6 +3,7 @@ package com.celuveat.celeb.adapter.out.persistence.entity
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -38,4 +39,7 @@ interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJp
     """,
     )
     fun findMostVisitedRestaurantsTop10(): List<RestaurantJpaEntity>
+
+    @EntityGraph(attributePaths = ["celebrity"])
+    fun findAllByRestaurantIdIn(restaurantIds: List<Long>): List<CelebrityRestaurantJpaEntity>
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityYoutubeContentJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityYoutubeContentJpaEntity.kt
@@ -24,7 +24,7 @@ class CelebrityYoutubeContentJpaEntity(
     @JoinColumn(name = "youtube_content_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val youtubeContent: YoutubeContentJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/InterestedCelebrityJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/InterestedCelebrityJpaEntity.kt
@@ -29,7 +29,7 @@ class InterestedCelebrityJpaEntity(
     @JoinColumn(name = "celebrity_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val celebrity: CelebrityJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/RestaurantInVideoJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/RestaurantInVideoJpaEntity.kt
@@ -25,7 +25,7 @@ class RestaurantInVideoJpaEntity(
     @JoinColumn(name = "video_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val video: VideoJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/VideoJpaEntity.kt
@@ -24,7 +24,7 @@ class VideoJpaEntity(
     @JoinColumn(name = "youtube_content_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val youtubeContent: YoutubeContentJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/YoutubeContentJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/YoutubeContentJpaEntity.kt
@@ -20,7 +20,7 @@ class YoutubeContentJpaEntity(
     val restaurantCount: Int,
     val subscriberCount: Long,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -88,6 +88,7 @@ class CelebrityQueryService(
             category = query.category,
             region = query.region,
             searchArea = query.searchArea,
+            celebrityId = null, // celebrityId is not used in this case
         )
         return readCelebritiesPort.readByRestaurants(restaurants.map { it.id })
             .map { SimpleCelebrityResult.from(it) }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -1,8 +1,10 @@
 package com.celuveat.celeb.application
 
 import com.celuveat.celeb.application.port.`in`.ReadBestCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.ReadCelebritiesInRestaurantConditionUseCase
 import com.celuveat.celeb.application.port.`in`.ReadCelebrityUseCase
 import com.celuveat.celeb.application.port.`in`.ReadInterestedCelebritiesUseCase
+import com.celuveat.celeb.application.port.`in`.query.ReadCelebritiesInRestaurantConditionQuery
 import com.celuveat.celeb.application.port.`in`.query.ReadCelebrityQuery
 import com.celuveat.celeb.application.port.`in`.result.BestCelebrityResult
 import com.celuveat.celeb.application.port.`in`.result.CelebrityResult
@@ -22,7 +24,10 @@ class CelebrityQueryService(
     private val readRestaurantPort: ReadRestaurantPort,
     private val readInterestedCelebritiesPort: ReadInterestedCelebritiesPort,
     private val readInterestedRestaurantPort: ReadInterestedRestaurantPort,
-) : ReadInterestedCelebritiesUseCase, ReadBestCelebritiesUseCase, ReadCelebrityUseCase {
+) : ReadInterestedCelebritiesUseCase,
+    ReadBestCelebritiesUseCase,
+    ReadCelebrityUseCase,
+    ReadCelebritiesInRestaurantConditionUseCase {
     override fun getInterestedCelebrities(memberId: Long): List<CelebrityResult> {
         val celebrities = readInterestedCelebritiesPort.readInterestedCelebrities(memberId)
         return celebrities.map { CelebrityResult.from(it.celebrity) }
@@ -76,5 +81,9 @@ class CelebrityQueryService(
             celebrity = celebrity,
             isInterested = interested,
         )
+    }
+
+    override fun readCelebrities(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult> {
+        TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -83,7 +83,13 @@ class CelebrityQueryService(
         )
     }
 
-    override fun readCelebrities(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult> {
-        TODO("Not yet implemented")
+    override fun readCelebritiesInRestaurantCondition(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult> {
+        val restaurants = readRestaurantPort.readRestaurantsByCondition(
+            category = query.category,
+            region = query.region,
+            searchArea = query.searchArea,
+        )
+        return readCelebritiesPort.readByRestaurants(restaurants.map { it.id })
+            .map { SimpleCelebrityResult.from(it) }
     }
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadCelebritiesInRestaurantConditionUseCase.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadCelebritiesInRestaurantConditionUseCase.kt
@@ -1,0 +1,9 @@
+package com.celuveat.celeb.application.port.`in`
+
+import com.celuveat.celeb.application.port.`in`.query.ReadCelebritiesInRestaurantConditionQuery
+import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
+
+interface ReadCelebritiesInRestaurantConditionUseCase {
+
+    fun readCelebrities(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult>
+}

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadCelebritiesInRestaurantConditionUseCase.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadCelebritiesInRestaurantConditionUseCase.kt
@@ -5,5 +5,5 @@ import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 
 interface ReadCelebritiesInRestaurantConditionUseCase {
 
-    fun readCelebrities(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult>
+    fun readCelebritiesInRestaurantCondition(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult>
 }

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/query/ReadCelebritiesInRestaurantConditionQuery.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/query/ReadCelebritiesInRestaurantConditionQuery.kt
@@ -1,0 +1,9 @@
+package com.celuveat.celeb.application.port.`in`.query
+
+import com.celuveat.common.utils.geometry.SquarePolygon
+
+data class ReadCelebritiesInRestaurantConditionQuery(
+    val category: String?,
+    val region: String?,
+    val searchArea: SquarePolygon?,
+)

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadCelebritiesPort.kt
@@ -5,7 +5,7 @@ import com.celuveat.celeb.domain.Celebrity
 interface ReadCelebritiesPort {
     fun readVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>>
 
-    fun readCelebritiesByRestaurants(restaurantIds: List<Long>): List<Celebrity>
+    fun readByRestaurants(restaurantIds: List<Long>): List<Celebrity>
 
     fun readVisitedCelebritiesByRestaurant(restaurantId: Long): List<Celebrity>
 

--- a/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadCelebritiesPort.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/out/ReadCelebritiesPort.kt
@@ -5,6 +5,8 @@ import com.celuveat.celeb.domain.Celebrity
 interface ReadCelebritiesPort {
     fun readVisitedCelebritiesByRestaurants(restaurantIds: List<Long>): Map<Long, List<Celebrity>>
 
+    fun readCelebritiesByRestaurants(restaurantIds: List<Long>): List<Celebrity>
+
     fun readVisitedCelebritiesByRestaurant(restaurantId: Long): List<Celebrity>
 
     fun readBestCelebrities(): List<Celebrity>

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/RootEntity.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/RootEntity.kt
@@ -2,10 +2,10 @@ package com.celuveat.common.adapter.out.persistence.entity
 
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
+import java.time.LocalDateTime
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import java.time.LocalDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
@@ -16,7 +16,7 @@ abstract class RootEntity<ID> {
     @LastModifiedDate
     lateinit var updatedAt: LocalDateTime
 
-    abstract fun id(): ID
+    abstract fun readId(): ID
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -24,10 +24,10 @@ abstract class RootEntity<ID> {
 
         other as RootEntity<*>
 
-        return id() == other.id()
+        return readId() == other.readId()
     }
 
     override fun hashCode(): Int {
-        return id()?.hashCode() ?: 0
+        return readId()?.hashCode() ?: 0
     }
 }

--- a/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/member/adapter/out/persistence/entity/MemberJpaEntity.kt
@@ -23,7 +23,7 @@ class MemberJpaEntity(
     val socialId: String,
     var refreshToken: String,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/notification/adapter/out/persistence/entity/NotificationJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/notification/adapter/out/persistence/entity/NotificationJpaEntity.kt
@@ -29,7 +29,7 @@ class NotificationJpaEntity(
     val content: String,
     var isRead: Boolean,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/region/adapter/out/persistence/entity/RegionJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/region/adapter/out/persistence/entity/RegionJpaEntity.kt
@@ -18,7 +18,7 @@ class RegionJpaEntity(
     val latitude: Double,
     val longitude: Double,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -179,6 +179,7 @@ class RestaurantController(
                 lowLatitude = request.lowLatitude,
                 highLatitude = request.highLatitude,
             ),
+            celebrityId = request.celebrityId,
         )
         return readAmountOfRestaurantsUseCase.readAmountOfRestaurants(query)
     }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/request/ReadRestaurantsRequest.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/request/ReadRestaurantsRequest.kt
@@ -48,6 +48,13 @@ data class ReadRestaurantsRequest(
         required = false,
     )
     val highLatitude: Double?,
+    @Parameter(
+        `in` = ParameterIn.QUERY,
+        description = "셀럽 ID",
+        example = "1",
+        required = false,
+    )
+    val celebrityId: Long?,
 ) {
     fun toQuery(
         memberId: Long?,
@@ -64,6 +71,7 @@ data class ReadRestaurantsRequest(
                 lowLatitude = lowLatitude,
                 highLatitude = highLatitude,
             ),
+            celebrityId = celebrityId,
             page = page,
             size = size,
         )

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -71,11 +71,12 @@ class RestaurantPersistenceAdapter(
         category: String?,
         region: String?,
         searchArea: SquarePolygon?,
+        celebrityId: Long?,
         page: Int,
         size: Int,
     ): SliceResult<Restaurant> {
         val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
-        val filter = RestaurantFilter(category, region, searchArea)
+        val filter = RestaurantFilter(category, region, searchArea, celebrityId)
         val restaurantSlice = restaurantJpaRepository.findAllByFilter(filter, pageRequest)
         val restaurants = restaurantSlice.content.map { it }
         val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurants)
@@ -95,9 +96,10 @@ class RestaurantPersistenceAdapter(
     override fun readRestaurantsByCondition(
         category: String?,
         region: String?,
-        searchArea: SquarePolygon?
+        searchArea: SquarePolygon?,
+        celebrityId: Long?,
     ): List<Restaurant> {
-        val filter = RestaurantFilter(category, region, searchArea)
+        val filter = RestaurantFilter(category, region, searchArea, celebrityId)
         val restaurants = restaurantJpaRepository.findAllByFilter(filter)
         val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurants)
             .groupBy { it.restaurant.id }
@@ -113,8 +115,16 @@ class RestaurantPersistenceAdapter(
         category: String?,
         region: String?,
         searchArea: SquarePolygon?,
+        celebrityId: Long?,
     ): Int {
-        return restaurantJpaRepository.countAllByFilter(RestaurantFilter(category, region, searchArea)).toInt()
+        return restaurantJpaRepository.countAllByFilter(
+            RestaurantFilter(
+                category = category,
+                region = region,
+                searchArea = searchArea,
+                celebrityId = celebrityId
+            )
+        ).toInt()
     }
 
     override fun readByCreatedAtBetween(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
@@ -10,6 +10,8 @@ interface CustomRestaurantRepository {
         pageable: Pageable,
     ): Slice<RestaurantJpaEntity>
 
+    fun findAllByFilter(filter: RestaurantFilter): List<RestaurantJpaEntity>
+
     fun countAllByFilter(filter: RestaurantFilter): Long
 }
 

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepository.kt
@@ -19,4 +19,5 @@ data class RestaurantFilter(
     val category: String?,
     val region: String?,
     val searchArea: SquarePolygon?,
+    val celebrityId: Long?,
 )

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.celuveat.restaurant.adapter.out.persistence.entity
 
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaEntity
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaEntity
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
@@ -26,6 +28,10 @@ class CustomRestaurantRepositoryImpl(
                 entity(RestaurantJpaEntity::class),
             ).from(
                 entity(RestaurantJpaEntity::class),
+                leftJoin(CelebrityRestaurantJpaEntity::class).on(
+                    path(CelebrityRestaurantJpaEntity::restaurant)(RestaurantJpaEntity::id)
+                        .eq(path(RestaurantJpaEntity::id))
+                ),
             ).whereAnd(
                 filter.category?.let { path(RestaurantJpaEntity::category).eq(it) },
                 filter.region?.let { path(RestaurantJpaEntity::roadAddress).like("%$it%") },
@@ -36,6 +42,7 @@ class CustomRestaurantRepositoryImpl(
                     )
                 },
                 filter.searchArea?.let { path(RestaurantJpaEntity::latitude).between(it.lowLatitude, it.highLatitude) },
+                filter.celebrityId?.let { path(CelebrityRestaurantJpaEntity::celebrity)(CelebrityJpaEntity::id).eq(it) },
             )
         }
         val restaurants = findSlice.content.filterNotNull()

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/InterestedRestaurantJpaEntity.kt
@@ -29,7 +29,7 @@ class InterestedRestaurantJpaEntity(
     @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val restaurant: RestaurantJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantImageJpaEntity.kt
@@ -25,7 +25,7 @@ class RestaurantImageJpaEntity(
     @JoinColumn(name = "restaurant_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val restaurant: RestaurantJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaEntity.kt
@@ -22,7 +22,7 @@ class RestaurantJpaEntity(
     val latitude: Double,
     val longitude: Double,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -27,10 +27,10 @@ import com.celuveat.restaurant.application.port.`in`.result.RestaurantDetailResu
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
-import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
+import org.springframework.stereotype.Service
 
 @Service
 class RestaurantQueryService(
@@ -110,6 +110,7 @@ class RestaurantQueryService(
             category = query.category,
             region = query.region,
             searchArea = query.searchArea,
+            celebrityId = query.celebrityId,
             page = query.page,
             size = query.size,
         )
@@ -130,6 +131,7 @@ class RestaurantQueryService(
             category = query.category,
             region = query.region,
             searchArea = query.searchArea,
+            celebrityId = query.celebrityId,
         )
     }
 

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadRestaurantsQuery.kt
@@ -9,6 +9,7 @@ data class ReadRestaurantsQuery(
     val category: String?,
     val region: String?,
     val searchArea: SquarePolygon?,
+    val celebrityId: Long?,
     val page: Int = 0,
     val size: Int = DEFAULT_RESTAURANTS_SIZE,
 )
@@ -17,4 +18,5 @@ data class CountRestaurantsQuery(
     val category: String?,
     val region: String?,
     val searchArea: SquarePolygon?,
+    val celebrityId: Long?,
 )

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -20,6 +20,7 @@ interface ReadRestaurantPort {
         category: String?,
         region: String?,
         searchArea: SquarePolygon?,
+        celebrityId: Long?,
         page: Int,
         size: Int,
     ): SliceResult<Restaurant>
@@ -28,12 +29,14 @@ interface ReadRestaurantPort {
         category: String?,
         region: String?,
         searchArea: SquarePolygon?,
+        celebrityId: Long?,
     ): List<Restaurant>
 
     fun countRestaurantsByCondition(
         category: String?,
         region: String?,
         searchArea: SquarePolygon?,
+        celebrityId: Long?,
     ): Int
 
     fun readByCreatedAtBetween(

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -24,6 +24,12 @@ interface ReadRestaurantPort {
         size: Int,
     ): SliceResult<Restaurant>
 
+    fun readRestaurantsByCondition(
+        category: String?,
+        region: String?,
+        searchArea: SquarePolygon?,
+    ): List<Restaurant>
+
     fun countRestaurantsByCondition(
         category: String?,
         region: String?,

--- a/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/HelpfulReviewJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/HelpfulReviewJpaEntity.kt
@@ -30,7 +30,7 @@ class HelpfulReviewJpaEntity(
     @JoinColumn(name = "member_id", foreignKey = ForeignKey(NO_CONSTRAINT))
     val member: MemberJpaEntity,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/ReviewImageJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/ReviewImageJpaEntity.kt
@@ -22,7 +22,7 @@ class ReviewImageJpaEntity(
     val review: ReviewJpaEntity,
     val imageUrl: String,
 ) : RootEntity<Long>() {
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/ReviewJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/review/adapter/out/persistence/entity/ReviewJpaEntity.kt
@@ -41,7 +41,7 @@ class ReviewJpaEntity(
         this.updatedAt = updatedAt
     }
 
-    override fun id(): Long {
+    override fun readId(): Long {
         return this.id
     }
 }

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -173,7 +173,7 @@ class CelebrityPersistenceAdapterTest(
         )
 
         // when
-        val celebrities = celebrityPersistenceAdapter.readCelebritiesByRestaurants(restaurants.map { it.id })
+        val celebrities = celebrityPersistenceAdapter.readByRestaurants(restaurants.map { it.id })
 
         // then
         celebrities.size shouldBe 2

--- a/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/adapter/out/persistence/CelebrityPersistenceAdapterTest.kt
@@ -2,6 +2,8 @@ package com.celuveat.celeb.adapter.out.persistence
 
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityJpaRepository
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaEntity
+import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityYoutubeContentJpaEntity
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityYoutubeContentJpaRepository
 import com.celuveat.celeb.adapter.out.persistence.entity.RestaurantInVideoJpaEntity
@@ -32,6 +34,7 @@ class CelebrityPersistenceAdapterTest(
     private val videoJpaRepository: VideoJpaRepository,
     private val restaurantJpaRepository: RestaurantJpaRepository,
     private val restaurantInVideoJpaRepository: RestaurantInVideoJpaRepository,
+    private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
 ) : FunSpec({
     test("식당을 방문한 셀럽을 조회 한다.") {
         // given
@@ -143,6 +146,37 @@ class CelebrityPersistenceAdapterTest(
             celebrities.size shouldBe 2
             celebrities.map { it.id } shouldContainExactly listOf(celebrityA.id, celebrityB.id)
         }
+    }
+
+    test("식당으로 셀럽을 조회 한다") {
+        // given
+        val savedCelebrities = celebrityJpaRepository.saveAll(sut.giveMeBuilder<CelebrityJpaEntity>().sampleList(3))
+        val celebrityA = savedCelebrities[0]
+        val celebrityB = savedCelebrities[1]
+
+        val restaurants = restaurantJpaRepository.saveAll(sut.giveMeBuilder<RestaurantJpaEntity>().sampleList(2))
+        celebrityRestaurantJpaRepository.saveAll(
+            listOf(
+                sut.giveMeBuilder<CelebrityRestaurantJpaEntity>()
+                    .set(CelebrityRestaurantJpaEntity::celebrity, celebrityA)
+                    .set(CelebrityRestaurantJpaEntity::restaurant, restaurants[0])
+                    .sample(),
+                sut.giveMeBuilder<CelebrityRestaurantJpaEntity>()
+                    .set(CelebrityRestaurantJpaEntity::celebrity, celebrityA)
+                    .set(CelebrityRestaurantJpaEntity::restaurant, restaurants[0])
+                    .sample(),
+                sut.giveMeBuilder<CelebrityRestaurantJpaEntity>()
+                    .set(CelebrityRestaurantJpaEntity::celebrity, celebrityB)
+                    .set(CelebrityRestaurantJpaEntity::restaurant, restaurants[1])
+                    .sample(),
+            ),
+        )
+
+        // when
+        val celebrities = celebrityPersistenceAdapter.readCelebritiesByRestaurants(restaurants.map { it.id })
+
+        // then
+        celebrities.size shouldBe 2
     }
 
     test("구독자가 많은 컨텐츠의 셀럽순으로 조회 한다.") {

--- a/src/test/kotlin/com/celuveat/celeb/application/CelebrityQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/application/CelebrityQueryServiceTest.kt
@@ -152,7 +152,8 @@ class CelebrityQueryServiceTest : BehaviorSpec({
                 readRestaurantPort.readRestaurantsByCondition(
                     category = query.category,
                     region = query.region,
-                    searchArea = query.searchArea
+                    searchArea = query.searchArea,
+                    celebrityId = null,
                 )
             } returns restaurants
             every { readCelebritiesPort.readByRestaurants(restaurants.map { it.id }) } returns celebrities

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -258,6 +258,7 @@ class RestaurantControllerTest(
                 region = region,
                 category = category,
                 searchArea = null,
+                celebrityId = null,
                 page = page,
                 size = size,
             )
@@ -302,6 +303,7 @@ class RestaurantControllerTest(
                     lowLatitude = 35.0,
                     highLatitude = 36.0,
                 ),
+                celebrityId = null,
                 page = page,
                 size = size,
             )

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -143,6 +143,7 @@ class RestaurantPersistenceAdapterTest(
             category = "한식",
             region = "서울",
             searchArea = null,
+            celebrityId = null,
             page = 0,
             size = 2,
         )
@@ -166,6 +167,7 @@ class RestaurantPersistenceAdapterTest(
             category = "한식",
             region = "서울",
             searchArea = null,
+            celebrityId = null,
         )
 
         // then
@@ -186,6 +188,7 @@ class RestaurantPersistenceAdapterTest(
             category = null,
             region = "서울",
             searchArea = null,
+            celebrityId = null,
             page = 0,
             size = 3,
         )
@@ -210,6 +213,7 @@ class RestaurantPersistenceAdapterTest(
             category = "한식",
             region = "서울",
             searchArea = null,
+            celebrityId = null,
         )
 
         // then

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -129,7 +129,7 @@ class RestaurantPersistenceAdapterTest(
         )
     }
 
-    test("조건에 따라 음식점을 검색한다.") {
+    test("조건에 따라 음식점을 페이징 검색한다.") {
         // given
         restaurantJpaRepository.saveAll(
             sut.giveMeBuilder<RestaurantJpaEntity>()
@@ -150,6 +150,26 @@ class RestaurantPersistenceAdapterTest(
         // then
         restaurants.size shouldBe 1
         restaurants.hasNext shouldBe false
+    }
+
+    test("조건에 따른 음식점을 전체 검색한다.") {
+        // given
+        restaurantJpaRepository.saveAll(
+            sut.giveMeBuilder<RestaurantJpaEntity>()
+                .setExp(RestaurantJpaEntity::category, "한식", 2)
+                .setExp(RestaurantJpaEntity::roadAddress, "서울", 1)
+                .sampleList(5),
+        )
+
+        // when
+        val restaurants = restaurantPersistenceAdapter.readRestaurantsByCondition(
+            category = "한식",
+            region = "서울",
+            searchArea = null,
+        )
+
+        // then
+        restaurants.size shouldBe 1
     }
 
     test("존재하지 않는 조건은 생략하고 검색한다.") {

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -242,6 +242,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     category = "한식",
                     region = "서울",
                     searchArea = null,
+                    celebrityId = null,
                     page = 0,
                     size = 5,
                 )
@@ -259,6 +260,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                 category = "한식",
                 region = "서울",
                 searchArea = null,
+                celebrityId = null,
                 page = 0,
                 size = 5,
             )
@@ -282,6 +284,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     category = "한식",
                     region = "서울",
                     searchArea = null,
+                    celebrityId = null,
                     page = 0,
                     size = 5,
                 )
@@ -293,6 +296,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                 category = "한식",
                 region = "서울",
                 searchArea = null,
+                celebrityId = null,
                 page = 0,
                 size = 5,
             )


### PR DESCRIPTION
# 관련 태스크
- closed #74 
---
- 지역 검색
- 카테고리 검색
- 지도 검색
해당 유스케이스 모두 `음식점 조건 조회(readRestaurants)` API를 사용하는데요.
이 때 사용 되는 조회 조건에 걸리는 모든 음식점에 대하여 방문한 셀럽을 응답하는 API를 만들었습니다. (`필터링에 사용 될 셀럽 조회`)

추가된 셀럽 필터링을 음식점 검색 조건에 추가하였습니다. e2ceefdb129af58b5b20b52ea99a268873927233
셀럽 필터링을 위해 동적 쿼리를 구성하던 중, `RootEntity<>`에서 선언한 메서드 `id()`와 Entity 필드들의 `id`가 Kotlin-jdsl에서 객체 프로퍼티를 추론할 때 오류가 발생하여 메서드 `id()` -> `readId()`로 수정하였습니다. (`getId()` 도 추론 오류) 
- https://kotlin-jdsl.gitbook.io/docs/ko-1/jpql-with-kotlin-jdsl/paths#java-entity

