### PR TITLE
feat: 셀럽 페이지 내 음식점 정렬 기능 추가

### DIFF
--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
@@ -5,7 +5,8 @@ import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJpaEntity, Long>,
+interface CelebrityRestaurantJpaRepository :
+    JpaRepository<CelebrityRestaurantJpaEntity, Long>,
     CustomCelebrityRestaurantRepository {
     @Query(
         """

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CelebrityRestaurantJpaRepository.kt
@@ -1,25 +1,12 @@
 package com.celuveat.celeb.adapter.out.persistence.entity
 
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJpaEntity, Long> {
-    @Query(
-        """
-        SELECT cr.restaurant
-        FROM CelebrityRestaurantJpaEntity cr
-        WHERE cr.celebrity.id = :celebrityId
-        """,
-    )
-    fun findRestaurantsByCelebrityId(
-        celebrityId: Long,
-        pageable: Pageable,
-    ): Slice<RestaurantJpaEntity>
-
+interface CelebrityRestaurantJpaRepository : JpaRepository<CelebrityRestaurantJpaEntity, Long>,
+    CustomCelebrityRestaurantRepository {
     @Query(
         """
         SELECT COUNT(cr)

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CustomCelebrityRestaurantRepository.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CustomCelebrityRestaurantRepository.kt
@@ -1,0 +1,14 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface CustomCelebrityRestaurantRepository {
+    fun findRestaurantsByCelebrityId(
+        celebrityId: Long,
+        pageable: Pageable,
+        sort: ReadCelebrityVisitedRestaurantSortCondition,
+    ): Slice<RestaurantJpaEntity>
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CustomCelebrityRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CustomCelebrityRestaurantRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.celuveat.celeb.adapter.out.persistence.entity
+
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition
+import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaEntity
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Repository
+
+@Repository
+class CustomCelebrityRestaurantRepositoryImpl(
+    private val executor: KotlinJdslJpqlExecutor,
+) : CustomCelebrityRestaurantRepository {
+
+    override fun findRestaurantsByCelebrityId(
+        celebrityId: Long,
+        pageable: Pageable,
+        sort: ReadCelebrityVisitedRestaurantSortCondition
+    ): Slice<RestaurantJpaEntity> {
+        val findSlice = executor.findSlice(pageable) {
+            select(
+                entity(RestaurantJpaEntity::class),
+            ).from(
+                entity(CelebrityRestaurantJpaEntity::class),
+                fetchJoin(CelebrityRestaurantJpaEntity::restaurant),
+            ).whereAnd(
+                path(CelebrityRestaurantJpaEntity::celebrity)
+                    .path(CelebrityJpaEntity::id)
+                    .eq(celebrityId),
+            ).orderBy(
+                when (sort) {
+                    ReadCelebrityVisitedRestaurantSortCondition.CREATED_AT -> path(RestaurantJpaEntity::createdAt).desc()
+                    ReadCelebrityVisitedRestaurantSortCondition.REVIEW -> path(RestaurantJpaEntity::reviewCount).desc()
+                    ReadCelebrityVisitedRestaurantSortCondition.LIKE -> path(RestaurantJpaEntity::likeCount).desc()
+                }
+            )
+        }
+        val restaurants = findSlice.content.filterNotNull()
+        return SliceImpl(
+            restaurants,
+            findSlice.pageable,
+            findSlice.hasNext(),
+        )
+    }
+}

--- a/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CustomCelebrityRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/celeb/adapter/out/persistence/entity/CustomCelebrityRestaurantRepositoryImpl.kt
@@ -12,15 +12,14 @@ import org.springframework.stereotype.Repository
 class CustomCelebrityRestaurantRepositoryImpl(
     private val executor: KotlinJdslJpqlExecutor,
 ) : CustomCelebrityRestaurantRepository {
-
     override fun findRestaurantsByCelebrityId(
         celebrityId: Long,
         pageable: Pageable,
-        sort: ReadCelebrityVisitedRestaurantSortCondition
+        sort: ReadCelebrityVisitedRestaurantSortCondition,
     ): Slice<RestaurantJpaEntity> {
         val findSlice = executor.findSlice(pageable) {
             select(
-                entity(RestaurantJpaEntity::class),
+                entity(CelebrityRestaurantJpaEntity::class),
             ).from(
                 entity(CelebrityRestaurantJpaEntity::class),
                 fetchJoin(CelebrityRestaurantJpaEntity::restaurant),
@@ -33,10 +32,10 @@ class CustomCelebrityRestaurantRepositoryImpl(
                     ReadCelebrityVisitedRestaurantSortCondition.CREATED_AT -> path(RestaurantJpaEntity::createdAt).desc()
                     ReadCelebrityVisitedRestaurantSortCondition.REVIEW -> path(RestaurantJpaEntity::reviewCount).desc()
                     ReadCelebrityVisitedRestaurantSortCondition.LIKE -> path(RestaurantJpaEntity::likeCount).desc()
-                }
+                },
             )
         }
-        val restaurants = findSlice.content.filterNotNull()
+        val restaurants = findSlice.content.filterNotNull().map { it.restaurant }
         return SliceImpl(
             restaurants,
             findSlice.pageable,

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -12,6 +12,7 @@ import com.celuveat.celeb.application.port.`in`.result.CelebrityWithInterestedRe
 import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.celeb.application.port.out.ReadInterestedCelebritiesPort
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition.LIKE
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
@@ -40,6 +41,7 @@ class CelebrityQueryService(
                 celebrityId = it.id,
                 page = 0,
                 size = 3,
+                sort = LIKE,  // TODO 정렬 좋아요(인기)? or 최신 순??
             ).contents
         }
         val interestedRestaurants = readInterestedRestaurants(memberId, restaurantsByCelebrity)

--- a/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/CelebrityQueryService.kt
@@ -41,7 +41,7 @@ class CelebrityQueryService(
                 celebrityId = it.id,
                 page = 0,
                 size = 3,
-                sort = LIKE,  // TODO 정렬 좋아요(인기)? or 최신 순??
+                sort = LIKE, // TODO 정렬 좋아요(인기)? or 최신 순??
             ).contents
         }
         val interestedRestaurants = readInterestedRestaurants(memberId, restaurantsByCelebrity)

--- a/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadCelebritiesInRestaurantConditionUseCase.kt
+++ b/src/main/kotlin/com/celuveat/celeb/application/port/in/ReadCelebritiesInRestaurantConditionUseCase.kt
@@ -4,6 +4,5 @@ import com.celuveat.celeb.application.port.`in`.query.ReadCelebritiesInRestauran
 import com.celuveat.celeb.application.port.`in`.result.SimpleCelebrityResult
 
 interface ReadCelebritiesInRestaurantConditionUseCase {
-
     fun readCelebritiesInRestaurantCondition(query: ReadCelebritiesInRestaurantConditionQuery): List<SimpleCelebrityResult>
 }

--- a/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/RootEntity.kt
+++ b/src/main/kotlin/com/celuveat/common/adapter/out/persistence/entity/RootEntity.kt
@@ -2,10 +2,10 @@ package com.celuveat.common.adapter.out.persistence.entity
 
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
-import java.time.LocalDateTime
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantApi.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "음식점 API")
 interface RestaurantApi {
@@ -75,6 +76,13 @@ interface RestaurantApi {
             required = true,
         )
         @PathVariable celebrityId: Long,
+        @Parameter(
+            `in` = ParameterIn.QUERY,
+            description = "정렬 조건 (생략 가능), review, like, createdAt 중 하나. 기본값은 like",
+            example = "review",
+            required = false,
+        )
+        @RequestParam("sort", required = false, defaultValue = "like") sortCondition: String,
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse>
 

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -4,6 +4,7 @@ import com.celuveat.auth.adapter.`in`.rest.Auth
 import com.celuveat.auth.adapter.`in`.rest.AuthContext
 import com.celuveat.common.adapter.`in`.rest.response.SliceResponse
 import com.celuveat.common.utils.geometry.SquarePolygon
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition
 import com.celuveat.restaurant.adapter.`in`.rest.request.ReadRestaurantsRequest
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantDetailResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/restaurants")
@@ -115,14 +117,17 @@ class RestaurantController(
     override fun readCelebrityVisitedRestaurant(
         @Auth auth: AuthContext,
         @PathVariable celebrityId: Long,
+        @RequestParam("sort", required = false, defaultValue = "like") sortCondition: String,
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse> {
+        val sort = ReadCelebrityVisitedRestaurantSortCondition.valueOf(sortCondition)
         val optionalMemberId = auth.optionalMemberId()
         val query = ReadCelebrityVisitedRestaurantQuery(
             memberId = optionalMemberId,
             celebrityId = celebrityId,
             page = pageable.pageNumber,
             size = pageable.pageSize,
+            sort = sort,
         )
         val visitedRestaurant = readCelebrityVisitedRestaurantUseCase.readCelebrityVisitedRestaurant(query)
         return SliceResponse.from(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantController.kt
@@ -120,7 +120,7 @@ class RestaurantController(
         @RequestParam("sort", required = false, defaultValue = "like") sortCondition: String,
         @PageableDefault(size = 10, page = 0) pageable: Pageable,
     ): SliceResponse<RestaurantPreviewResponse> {
-        val sort = ReadCelebrityVisitedRestaurantSortCondition.valueOf(sortCondition)
+        val sort = ReadCelebrityVisitedRestaurantSortCondition.from(sortCondition)
         val optionalMemberId = auth.optionalMemberId()
         val query = ReadCelebrityVisitedRestaurantQuery(
             memberId = optionalMemberId,

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/request/ReadCelebrityVisitedRestaurantSortCondition.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/request/ReadCelebrityVisitedRestaurantSortCondition.kt
@@ -1,7 +1,18 @@
 package com.celuveat.restaurant.adapter.`in`.rest.request
 
-enum class ReadCelebrityVisitedRestaurantSortCondition {
-    LIKE,  // 좋아요 많은 순
-    REVIEW,  // 리뷰 많은 순
-    CREATED_AT,  // 최신 순
+enum class ReadCelebrityVisitedRestaurantSortCondition(
+    private val value: String,
+) {
+    LIKE("like"), // 좋아요 많은 순
+    REVIEW("review"), // 리뷰 많은 순
+    CREATED_AT("createdAt"), // 최신 순
+    ;
+
+    companion object {
+        fun from(sortCondition: String): ReadCelebrityVisitedRestaurantSortCondition {
+            return ReadCelebrityVisitedRestaurantSortCondition.entries
+                .findLast { it.value.equals(sortCondition, ignoreCase = true) }
+                ?: throw IllegalArgumentException("정렬 조건은 like, review, createdAt 중 하나입니다. 현재 : $sortCondition")
+        }
+    }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/request/ReadCelebrityVisitedRestaurantSortCondition.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/request/ReadCelebrityVisitedRestaurantSortCondition.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.adapter.`in`.rest.request
+
+enum class ReadCelebrityVisitedRestaurantSortCondition {
+    LIKE,  // 좋아요 많은 순
+    REVIEW,  // 리뷰 많은 순
+    CREATED_AT,  // 최신 순
+}

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantDetailResponse.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/in/rest/response/RestaurantDetailResponse.kt
@@ -61,6 +61,14 @@ data class RestaurantPreviewResponse(
         description = "이미지 목록",
     )
     val images: List<RestaurantImageResponse>,
+    @Schema(
+        description = "리뷰 수",
+    )
+    val reviewCount: Int,
+    @Schema(
+        description = "좋아요 수",
+    )
+    val likeCount: Int,
 ) {
     companion object {
         fun from(result: RestaurantPreviewResult): RestaurantPreviewResponse {
@@ -76,6 +84,8 @@ data class RestaurantPreviewResponse(
                 liked = result.liked,
                 visitedCelebrities = result.visitedCelebrities.map { SimpleCelebrityResponse.from(it) },
                 images = result.images.map { RestaurantImageResponse.from(it) },
+                reviewCount = result.reviewCount,
+                likeCount = result.likeCount,
             )
         }
     }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -4,17 +4,19 @@ import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaR
 import com.celuveat.common.annotation.Adapter
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.common.utils.geometry.SquarePolygon
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition
 import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantFilter
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantPersistenceMapper
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
-import java.time.LocalDate
-import java.time.LocalTime
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import java.time.LocalDate
+import java.time.LocalTime
 
 @Adapter
 class RestaurantPersistenceAdapter(
@@ -28,9 +30,14 @@ class RestaurantPersistenceAdapter(
         celebrityId: Long,
         page: Int,
         size: Int,
+        sort: ReadCelebrityVisitedRestaurantSortCondition,
     ): SliceResult<Restaurant> {
         val pageRequest = PageRequest.of(page, size, LATEST_SORTER)
-        val restaurantSlice = celebrityRestaurantJpaRepository.findRestaurantsByCelebrityId(celebrityId, pageRequest)
+        val restaurantSlice = celebrityRestaurantJpaRepository.findRestaurantsByCelebrityId(
+            celebrityId,
+            pageRequest,
+            sort
+        )
         val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurantSlice.content)
             .groupBy { it.restaurant.id }
         return SliceResult.of(

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -23,7 +23,7 @@ class RestaurantPersistenceAdapter(
     private val interestedRestaurantJpaRepository: InterestedRestaurantJpaRepository,
     private val celebrityRestaurantJpaRepository: CelebrityRestaurantJpaRepository,
     private val restaurantJpaRepository: RestaurantJpaRepository,
-) : ReadRestaurantPort {
+) : ReadRestaurantPort, SaveRestaurantPort {
     override fun readVisitedRestaurantByCelebrity(
         celebrityId: Long,
         page: Int,
@@ -204,5 +204,10 @@ class RestaurantPersistenceAdapter(
 
     companion object {
         val LATEST_SORTER = Sort.by("createdAt").descending()
+    }
+
+    override fun save(restaurant: Restaurant) {
+        val entity = restaurantPersistenceMapper.toEntity(restaurant)
+        restaurantJpaRepository.save(entity)
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapter.kt
@@ -36,7 +36,7 @@ class RestaurantPersistenceAdapter(
         val restaurantSlice = celebrityRestaurantJpaRepository.findRestaurantsByCelebrityId(
             celebrityId,
             pageRequest,
-            sort
+            sort,
         )
         val imagesByRestaurants = restaurantImageJpaRepository.findByRestaurantIn(restaurantSlice.content)
             .groupBy { it.restaurant.id }
@@ -129,8 +129,8 @@ class RestaurantPersistenceAdapter(
                 category = category,
                 region = region,
                 searchArea = searchArea,
-                celebrityId = celebrityId
-            )
+                celebrityId = celebrityId,
+            ),
         ).toInt()
     }
 

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/CustomRestaurantRepositoryImpl.kt
@@ -30,7 +30,7 @@ class CustomRestaurantRepositoryImpl(
                 entity(RestaurantJpaEntity::class),
                 leftJoin(CelebrityRestaurantJpaEntity::class).on(
                     path(CelebrityRestaurantJpaEntity::restaurant)(RestaurantJpaEntity::id)
-                        .eq(path(RestaurantJpaEntity::id))
+                        .eq(path(RestaurantJpaEntity::id)),
                 ),
             ).whereAnd(
                 filter.category?.let { path(RestaurantJpaEntity::category).eq(it) },

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaEntity.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantJpaEntity.kt
@@ -21,6 +21,8 @@ class RestaurantJpaEntity(
     val naverMapUrl: String,
     val latitude: Double,
     val longitude: Double,
+    val reviewCount: Int = 0,
+    val likeCount: Int = 0,
 ) : RootEntity<Long>() {
     override fun readId(): Long {
         return this.id

--- a/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantPersistenceMapper.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/adapter/out/persistence/entity/RestaurantPersistenceMapper.kt
@@ -30,6 +30,8 @@ class RestaurantPersistenceMapper {
                     isThumbnail = imageJpaEntity.isThumbnail,
                 )
             },
+            reviewCount = restaurant.reviewCount,
+            likeCount = restaurant.likeCount,
         )
     }
 
@@ -46,6 +48,8 @@ class RestaurantPersistenceMapper {
             latitude = restaurant.latitude,
             longitude = restaurant.longitude,
             images = emptyList(),
+            reviewCount = restaurant.reviewCount,
+            likeCount = restaurant.likeCount,
         )
     }
 
@@ -61,6 +65,8 @@ class RestaurantPersistenceMapper {
             naverMapUrl = restaurant.naverMapUrl,
             latitude = restaurant.latitude,
             longitude = restaurant.longitude,
+            reviewCount = restaurant.reviewCount,
+            likeCount = restaurant.likeCount,
         )
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -76,6 +76,7 @@ class RestaurantQueryService(
             query.celebrityId,
             query.page,
             query.size,
+            query.sort,
         )
         val visitedRestaurantIds = visitedRestaurants.contents.map { it.id }
         val interestedRestaurants = readInterestedRestaurants(query.memberId, visitedRestaurantIds)

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantQueryService.kt
@@ -27,10 +27,10 @@ import com.celuveat.restaurant.application.port.`in`.result.RestaurantDetailResu
 import com.celuveat.restaurant.application.port.`in`.result.RestaurantPreviewResult
 import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
+import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
-import org.springframework.stereotype.Service
 
 @Service
 class RestaurantQueryService(

--- a/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/RestaurantService.kt
@@ -7,7 +7,9 @@ import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestau
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
 import org.springframework.stereotype.Service
 
@@ -16,21 +18,29 @@ class RestaurantService(
     private val saveInterestedRestaurantPort: SaveInterestedRestaurantPort,
     private val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort,
     private val readInterestedRestaurantPort: ReadInterestedRestaurantPort,
+    private val readRestaurantPort: ReadRestaurantPort,
+    private val saveRestaurantPort: SaveRestaurantPort,
 ) : AddInterestedRestaurantsUseCase, DeleteInterestedRestaurantsUseCase {
     override fun addInterestedRestaurant(command: AddInterestedRestaurantCommand) {
         throwWhen(
             readInterestedRestaurantPort.existsInterestedRestaurant(command.memberId, command.restaurantId),
         ) { AlreadyInterestedRestaurantException }
+        val restaurant = readRestaurantPort.readById(command.restaurantId)
         saveInterestedRestaurantPort.saveInterestedRestaurant(
             memberId = command.memberId,
             restaurantId = command.restaurantId,
         )
+        restaurant.increaseLikeCount()
+        saveRestaurantPort.save(restaurant)
     }
 
     override fun deleteInterestedRestaurant(command: DeleteInterestedRestaurantCommand) {
+        val restaurant = readRestaurantPort.readById(command.restaurantId)
         deleteInterestedRestaurantPort.deleteInterestedRestaurant(
             memberId = command.memberId,
             restaurantId = command.restaurantId,
         )
+        restaurant.decreaseLikeCount()
+        saveRestaurantPort.save(restaurant)
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
@@ -1,5 +1,7 @@
 package com.celuveat.restaurant.application.port.`in`.query
 
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition
+
 private const val DEFAULT_VISITED_RESTAURANTS_SIZE = 10
 
 data class ReadCelebrityVisitedRestaurantQuery(
@@ -7,4 +9,5 @@ data class ReadCelebrityVisitedRestaurantQuery(
     val celebrityId: Long,
     val page: Int = 0,
     val size: Int = DEFAULT_VISITED_RESTAURANTS_SIZE,
+    val sort: ReadCelebrityVisitedRestaurantSortCondition
 )

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/query/ReadCelebrityVisitedRestaurantQuery.kt
@@ -9,5 +9,5 @@ data class ReadCelebrityVisitedRestaurantQuery(
     val celebrityId: Long,
     val page: Int = 0,
     val size: Int = DEFAULT_VISITED_RESTAURANTS_SIZE,
-    val sort: ReadCelebrityVisitedRestaurantSortCondition
+    val sort: ReadCelebrityVisitedRestaurantSortCondition,
 )

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/in/result/RestaurantPreviewResult.kt
@@ -17,6 +17,8 @@ data class RestaurantPreviewResult(
     val liked: Boolean,
     val visitedCelebrities: List<SimpleCelebrityResult>,
     val images: List<RestaurantImageResult>,
+    val reviewCount: Int,
+    val likeCount: Int,
 ) {
     companion object {
         fun of(
@@ -36,6 +38,8 @@ data class RestaurantPreviewResult(
                 liked = liked,
                 visitedCelebrities = visitedCelebrities.map { SimpleCelebrityResult.from(it) },
                 images = restaurant.images.map { RestaurantImageResult.from(it) },
+                reviewCount = restaurant.reviewCount,
+                likeCount = restaurant.likeCount,
             )
         }
     }

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/ReadRestaurantPort.kt
@@ -2,6 +2,7 @@ package com.celuveat.restaurant.application.port.out
 
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.common.utils.geometry.SquarePolygon
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition
 import com.celuveat.restaurant.domain.Restaurant
 import java.time.LocalDate
 
@@ -10,6 +11,7 @@ interface ReadRestaurantPort {
         celebrityId: Long,
         page: Int,
         size: Int,
+        sort: ReadCelebrityVisitedRestaurantSortCondition,
     ): SliceResult<Restaurant>
 
     fun readById(id: Long): Restaurant

--- a/src/main/kotlin/com/celuveat/restaurant/application/port/out/SaveRestaurantPort.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/application/port/out/SaveRestaurantPort.kt
@@ -1,0 +1,7 @@
+package com.celuveat.restaurant.application.port.out
+
+import com.celuveat.restaurant.domain.Restaurant
+
+interface SaveRestaurantPort {
+    fun save(restaurant: Restaurant)
+}

--- a/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
@@ -16,18 +16,18 @@ data class Restaurant(
     var likeCount: Int = 0,
 ) {
     fun increaseReviewCount() {
-        reviewCount += 1;
+        reviewCount += 1
     }
 
     fun decreaseReviewCount() {
-        reviewCount -= 1;
+        reviewCount -= 1
     }
 
     fun increaseLikeCount() {
-        likeCount += 1;
+        likeCount += 1
     }
 
     fun decreaseLikeCount() {
-        likeCount -= 1;
+        likeCount -= 1
     }
 }

--- a/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
+++ b/src/main/kotlin/com/celuveat/restaurant/domain/Restaurant.kt
@@ -12,4 +12,22 @@ data class Restaurant(
     val latitude: Double = 0.0,
     val longitude: Double = 0.0,
     val images: List<RestaurantImage>,
-)
+    var reviewCount: Int = 0,
+    var likeCount: Int = 0,
+) {
+    fun increaseReviewCount() {
+        reviewCount += 1;
+    }
+
+    fun decreaseReviewCount() {
+        reviewCount -= 1;
+    }
+
+    fun increaseLikeCount() {
+        likeCount += 1;
+    }
+
+    fun decreaseLikeCount() {
+        likeCount -= 1;
+    }
+}

--- a/src/main/kotlin/com/celuveat/review/application/ReviewService.kt
+++ b/src/main/kotlin/com/celuveat/review/application/ReviewService.kt
@@ -3,6 +3,7 @@ package com.celuveat.review.application
 import com.celuveat.common.utils.throwWhen
 import com.celuveat.member.application.port.out.ReadMemberPort
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import com.celuveat.review.application.port.`in`.ClickHelpfulReviewUseCase
 import com.celuveat.review.application.port.`in`.DeleteHelpfulReviewUseCase
 import com.celuveat.review.application.port.`in`.DeleteReviewUseCase
@@ -30,6 +31,7 @@ class ReviewService(
     private val saveReviewPort: SaveReviewPort,
     private val deleteReviewPort: DeleteReviewPort,
     private val deleteHelpfulReviewPort: DeleteHelpfulReviewPort,
+    private val saveRestaurantPort: SaveRestaurantPort,
 ) : WriteReviewUseCase,
     UpdateReviewUseCase,
     DeleteReviewUseCase,
@@ -39,6 +41,8 @@ class ReviewService(
         val member = readMemberPort.readById(command.memberId)
         val restaurant = readRestaurantPort.readById(command.restaurantId)
         val review = command.toReview(member, restaurant)
+        restaurant.increaseReviewCount()
+        saveRestaurantPort.save(restaurant)
         return saveReviewPort.save(review).id
     }
 
@@ -57,6 +61,8 @@ class ReviewService(
         val member = readMemberPort.readById(memberId)
         val review = readReviewPort.readById(reviewId)
         review.validateWriter(member)
+        review.restaurant.decreaseReviewCount()
+        saveRestaurantPort.save(review.restaurant)
         deleteReviewPort.delete(review)
     }
 

--- a/src/test/kotlin/com/celuveat/celeb/application/CelebrityQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/celeb/application/CelebrityQueryServiceTest.kt
@@ -77,7 +77,7 @@ class CelebrityQueryServiceTest : BehaviorSpec({
 
         When("회원이 조회하면") {
             every { readCelebritiesPort.readBestCelebrities() } returns celebrityResult
-            every { readRestaurantPort.readVisitedRestaurantByCelebrity(any(), any(), any()) } returns
+            every { readRestaurantPort.readVisitedRestaurantByCelebrity(any(), any(), any(), any()) } returns
                     SliceResult.of(restaurantsA, 0, false) andThen
                     SliceResult.of(restaurantsB, 0, false)
             every { readInterestedRestaurantPort.readInterestedRestaurantsByIds(memberId, any()) } returns
@@ -94,7 +94,7 @@ class CelebrityQueryServiceTest : BehaviorSpec({
 
         When("비회원이 조회하면") {
             every { readCelebritiesPort.readBestCelebrities() } returns celebrityResult
-            every { readRestaurantPort.readVisitedRestaurantByCelebrity(any(), any(), any()) } returns
+            every { readRestaurantPort.readVisitedRestaurantByCelebrity(any(), any(), any(), any()) } returns
                     SliceResult.of(restaurantsA, 0, false) andThen
                     SliceResult.of(restaurantsB, 0, false)
 

--- a/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/member/application/SocialLoginServiceTest.kt
@@ -60,7 +60,7 @@ class SocialLoginServiceTest : BehaviorSpec({
 
             every { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) } returns member
             every { readMemberPort.findBySocialIdentifier(socialIdentifier) } returns null
-            every { saveMemberPort.save(member) } returns savedMember
+            every { saveMemberPort.save(any()) } returns savedMember
             val command = SocialLoginCommand(serverType, authCode, redirectUrl)
 
             val result = socialLoginService.login(command)
@@ -69,7 +69,7 @@ class SocialLoginServiceTest : BehaviorSpec({
 
                 verify { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) }
                 verify { readMemberPort.findBySocialIdentifier(socialIdentifier) }
-                verify(exactly = 2) { saveMemberPort.save(member) }
+                verify(exactly = 2) { saveMemberPort.save(any()) }
             }
         }
 
@@ -84,7 +84,7 @@ class SocialLoginServiceTest : BehaviorSpec({
 
             every { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) } returns member
             every { readMemberPort.findBySocialIdentifier(socialIdentifier) } returns savedMember
-            every { saveMemberPort.save(member) } returns member
+            every { saveMemberPort.save(any()) } returns savedMember
             val command = SocialLoginCommand(serverType, authCode, redirectUrl)
 
             val result = socialLoginService.login(command)
@@ -93,7 +93,7 @@ class SocialLoginServiceTest : BehaviorSpec({
 
                 verify { fetchSocialMemberPort.fetchMember(serverType, authCode, redirectUrl) }
                 verify { readMemberPort.findBySocialIdentifier(socialIdentifier) }
-                verify(exactly = 1) { saveMemberPort.save(member) }
+                verify(exactly = 1) { saveMemberPort.save(any()) }
             }
         }
     }

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/in/rest/RestaurantControllerTest.kt
@@ -4,6 +4,7 @@ import com.celuveat.auth.application.port.`in`.ExtractMemberIdUseCase
 import com.celuveat.common.adapter.`in`.rest.response.SliceResponse
 import com.celuveat.common.application.port.`in`.result.SliceResult
 import com.celuveat.common.utils.geometry.SquarePolygon
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition.LIKE
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantDetailResponse
 import com.celuveat.restaurant.adapter.`in`.rest.response.RestaurantPreviewResponse
 import com.celuveat.restaurant.application.port.`in`.AddInterestedRestaurantsUseCase
@@ -157,7 +158,7 @@ class RestaurantControllerTest(
                 hasNext = false,
             )
             val response = SliceResponse.from(results, RestaurantPreviewResponse::from)
-            val query = ReadCelebrityVisitedRestaurantQuery(memberId, celebrityId, page, size = 3)
+            val query = ReadCelebrityVisitedRestaurantQuery(memberId, celebrityId, page, size = 3, sort = LIKE)
 
             every { extractMemberIdUseCase.extract(accessToken) } returns memberId
             every { readCelebrityVisitedRestaurantUseCase.readCelebrityVisitedRestaurant(query) } returns results
@@ -183,7 +184,7 @@ class RestaurantControllerTest(
                 hasNext = false,
             )
             val response = SliceResponse.from(results, RestaurantPreviewResponse::from)
-            val query = ReadCelebrityVisitedRestaurantQuery(null, celebrityId, page, size = 3)
+            val query = ReadCelebrityVisitedRestaurantQuery(null, celebrityId, page, size = 3, sort = LIKE)
 
             every { readCelebrityVisitedRestaurantUseCase.readCelebrityVisitedRestaurant(query) } returns results
 

--- a/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/adapter/out/persistence/RestaurantPersistenceAdapterTest.kt
@@ -6,6 +6,7 @@ import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaE
 import com.celuveat.celeb.adapter.out.persistence.entity.CelebrityRestaurantJpaRepository
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaEntity
 import com.celuveat.member.adapter.out.persistence.entity.MemberJpaRepository
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition.CREATED_AT
 import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaEntity
 import com.celuveat.restaurant.adapter.out.persistence.entity.InterestedRestaurantJpaRepository
 import com.celuveat.restaurant.adapter.out.persistence.entity.RestaurantImageJpaEntity
@@ -66,6 +67,7 @@ class RestaurantPersistenceAdapterTest(
             celebrityId = savedCelebrity.id,
             page = 0,
             size = 2,
+            sort = CREATED_AT,
         )
 
         // then

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantQueryServiceTest.kt
@@ -4,6 +4,7 @@ import com.celuveat.celeb.application.port.out.ReadCelebritiesPort
 import com.celuveat.celeb.domain.Celebrity
 import com.celuveat.celeb.domain.YoutubeContent
 import com.celuveat.common.application.port.`in`.result.SliceResult
+import com.celuveat.restaurant.adapter.`in`.rest.request.ReadCelebrityVisitedRestaurantSortCondition.CREATED_AT
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityRecommendRestaurantsQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadCelebrityVisitedRestaurantQuery
 import com.celuveat.restaurant.application.port.`in`.query.ReadInterestedRestaurantsQuery
@@ -92,6 +93,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
         val celebrityId = 1L
         val page = 0
         val size = 2
+        val sort = CREATED_AT
         val visitedRestaurantResult = SliceResult.of(
             contents = sut.giveMeBuilder<Restaurant>().sampleList(2),
             currentPage = 0,
@@ -104,6 +106,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     celebrityId,
                     page,
                     size,
+                    sort,
                 )
             } returns visitedRestaurantResult
             val memberId = 1L
@@ -123,6 +126,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                 celebrityId = celebrityId,
                 page = page,
                 size = size,
+                sort = sort,
             )
             val visitedRestaurants =
                 restaurantQueryService.readCelebrityVisitedRestaurant(readCelebrityVisitedRestaurantQuery)
@@ -139,6 +143,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                     celebrityId,
                     page,
                     size,
+                    sort,
                 )
             } returns visitedRestaurantResult
             val readCelebrityVisitedRestaurantQuery = ReadCelebrityVisitedRestaurantQuery(
@@ -146,6 +151,7 @@ class RestaurantQueryServiceTest : BehaviorSpec({
                 celebrityId = celebrityId,
                 page = page,
                 size = size,
+                sort = sort,
             )
             val visitedRestaurants =
                 restaurantQueryService.readCelebrityVisitedRestaurant(readCelebrityVisitedRestaurantQuery)

--- a/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/restaurant/application/RestaurantServiceTest.kt
@@ -4,8 +4,12 @@ import com.celuveat.restaurant.application.port.`in`.command.AddInterestedRestau
 import com.celuveat.restaurant.application.port.`in`.command.DeleteInterestedRestaurantCommand
 import com.celuveat.restaurant.application.port.out.DeleteInterestedRestaurantPort
 import com.celuveat.restaurant.application.port.out.ReadInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
 import com.celuveat.restaurant.application.port.out.SaveInterestedRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
+import com.celuveat.restaurant.domain.Restaurant
 import com.celuveat.restaurant.exception.AlreadyInterestedRestaurantException
+import com.celuveat.support.sut
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.test.TestCase
@@ -20,20 +24,27 @@ class RestaurantServiceTest : BehaviorSpec({
     val saveInterestedRestaurantPort: SaveInterestedRestaurantPort = mockk()
     val deleteInterestedRestaurantPort: DeleteInterestedRestaurantPort = mockk()
     val readInterestedRestaurantPort: ReadInterestedRestaurantPort = mockk()
+    val readRestaurantPort: ReadRestaurantPort = mockk()
+    val saveRestaurantPort: SaveRestaurantPort = mockk()
 
     val restaurantService = RestaurantService(
         saveInterestedRestaurantPort,
         deleteInterestedRestaurantPort,
         readInterestedRestaurantPort,
+        readRestaurantPort,
+        saveRestaurantPort,
     )
 
     Given("회원이 관심 음식점 추가 시") {
         val memberId = 1L
         val restaurantId = 1L
+        val restaurant = sut.giveMeOne(Restaurant::class.java)
 
         When("해당 음식점이") {
             every { saveInterestedRestaurantPort.saveInterestedRestaurant(memberId, restaurantId) } returns Unit
             every { readInterestedRestaurantPort.existsInterestedRestaurant(memberId, restaurantId) } returns false
+            every { readRestaurantPort.readById(restaurantId) } returns restaurant
+            every { saveRestaurantPort.save(any()) } returns Unit
 
             val command = AddInterestedRestaurantCommand(memberId, restaurantId)
             restaurantService.addInterestedRestaurant(command)
@@ -57,9 +68,12 @@ class RestaurantServiceTest : BehaviorSpec({
     Given("회원이 관심 음식점 삭제 시") {
         val memberId = 1L
         val restaurantId = 1L
+        val restaurant = sut.giveMeOne(Restaurant::class.java)
 
         When("해당 음식점이") {
             every { deleteInterestedRestaurantPort.deleteInterestedRestaurant(memberId, restaurantId) } returns Unit
+            every { readRestaurantPort.readById(restaurantId) } returns restaurant
+            every { saveRestaurantPort.save(any()) } returns Unit
 
             val command = DeleteInterestedRestaurantCommand(memberId, restaurantId)
             restaurantService.deleteInterestedRestaurant(command)

--- a/src/test/kotlin/com/celuveat/review/application/port/ReviewServiceTest.kt
+++ b/src/test/kotlin/com/celuveat/review/application/port/ReviewServiceTest.kt
@@ -3,6 +3,7 @@ package com.celuveat.review.application.port
 import com.celuveat.member.application.port.out.ReadMemberPort
 import com.celuveat.member.domain.Member
 import com.celuveat.restaurant.application.port.out.ReadRestaurantPort
+import com.celuveat.restaurant.application.port.out.SaveRestaurantPort
 import com.celuveat.restaurant.domain.Restaurant
 import com.celuveat.review.application.ReviewService
 import com.celuveat.review.application.port.`in`.command.UpdateReviewCommand
@@ -44,6 +45,7 @@ class ReviewServiceTest : BehaviorSpec({
     val saveReviewPort: SaveReviewPort = mockk()
     val deleteReviewPort: DeleteReviewPort = mockk()
     val deleteHelpfulReviewPort: DeleteHelpfulReviewPort = mockk()
+    val saveRestaurantPort: SaveRestaurantPort = mockk()
 
     val reviewService = ReviewService(
         readMemberPort,
@@ -54,6 +56,7 @@ class ReviewServiceTest : BehaviorSpec({
         saveReviewPort,
         deleteReviewPort,
         deleteHelpfulReviewPort,
+        saveRestaurantPort,
     )
 
     Given("리뷰 작성 시") {
@@ -64,6 +67,7 @@ class ReviewServiceTest : BehaviorSpec({
         every { readMemberPort.readById(1L) } returns member
         every { readRestaurantPort.readById(1L) } returns restaurant
         every { saveReviewPort.save(any()) } returns review
+        every { saveRestaurantPort.save(any()) } returns Unit
 
         When("회원이 리뷰를 작성하면") {
 
@@ -126,6 +130,7 @@ class ReviewServiceTest : BehaviorSpec({
             every { deleteReviewPort.delete(any()) } just Runs
             every { readMemberPort.readById(1L) } returns member
             every { readReviewPort.readById(1L) } returns review
+            every { saveRestaurantPort.save(any()) } returns Unit
             reviewService.delete(1L, 1L)
 
             Then("리뷰가 삭제된다.") {


### PR DESCRIPTION
셀럽 페이지 내에서 음식점 정렬 기능 추가했습니다.
직접 API 쏴보고 테스트 해보긴 했는데, jdsl 사용이 처음이라 오류가 있을수도... (확인 잘 부탁드립니당)
TODO 도 하나 남겼으니 확인 부탁드려욤!

추가로 음식점 조회 시 리뷰 수, 좋아요 수를 보여주기 위해 이를 증감시키는 로직도 작성했는데,
lock 걸어야 할 듯요..? (일단은 냅둠)